### PR TITLE
Update causal model visualization

### DIFF
--- a/demos/causal_model_intro.ipynb
+++ b/demos/causal_model_intro.ipynb
@@ -1,0 +1,691 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8fcbce65",
+   "metadata": {},
+   "source": [
+    "# What's a causal model?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c56e9f89",
+   "metadata": {},
+   "source": [
+    "Neural networks are complex and interesting systems -- yet we have full control over their internals! Interpretability seeks to understand how manipulations of model internals affect their output. The theory of causality, which formalizes causal effects in causal graphs, is fundamental to the field of interpretability.\n",
+    "\n",
+    "But what exactly is a causal model? In this tutorial, we walk through a simple causal model with the `CausalAbstraction` library. Along the way, we'll discuss\n",
+    "* The components of causal graphs,\n",
+    "* Operations we can perform on causal graphs,\n",
+    "* and abstractions between causal graphs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f938c637",
+   "metadata": {},
+   "source": [
+    "## Let's set up a causal model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b589ac2",
+   "metadata": {},
+   "source": [
+    "Imagine we trained a neural network to add three numbers, A, B, and C, together. How might it solve this problem?\n",
+    "\n",
+    "We can formalize our **hypothesis** as a **causal graph**. The code below sets up a causal graph for an algorithm that adds the three numbers left to right. The causal model first adds A and B together, and then adds C to their sum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "34ee6552",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
+    "import random\n",
+    "# we use the CausalAbstraction library to set up a causal model\n",
+    "from causal.causal_model import CausalModel\n",
+    "\n",
+    "DIGITS = list(range(0, 10))\n",
+    "\n",
+    "######################\n",
+    "# 1. variables       #\n",
+    "######################\n",
+    "# first we specify the variables of our causal model\n",
+    "# A, B, C : the inputs to our model\n",
+    "# A+B : the intermediate operation A + B\n",
+    "# C' : the intermediate value of C (copied from the input)\n",
+    "# Y : the final sum, A + B + C\n",
+    "# raw_input : the raw representation of the inputs (A, B, and C)\n",
+    "# raw_output : the raw representation of the output (Y)\n",
+    "variables = [\n",
+    "    \"A\", \"B\", \"C\", \n",
+    "    \"A+B\", \n",
+    "    \"C\\'\",\n",
+    "    \"Y\", \n",
+    "    \"raw_input\", \n",
+    "    \"raw_output\"\n",
+    "]\n",
+    "\n",
+    "######################\n",
+    "# 2. values          #\n",
+    "######################\n",
+    "# what values can our variables take on?\n",
+    "# in this case, let's imagine modular arithmetic, so all\n",
+    "# of our variables (except the raw input/output strings) \n",
+    "# can only take on a value from 0 to 9.\n",
+    "values = {\n",
+    "    **{var: DIGITS for var in variables},\n",
+    "    \"raw_input\": None, \"raw_output\": None\n",
+    "}\n",
+    "\n",
+    "######################\n",
+    "# 3. parents         #\n",
+    "######################\n",
+    "# this helps us specify the direction of our causal graph\n",
+    "# A, B, C : no parents, bc they're inputs\n",
+    "# A+B : parents are A and B\n",
+    "# C' : parent is C\n",
+    "# Y : parents are A+B and C' (NOT A, B, or C!)\n",
+    "# raw_input : parents are A, B, and C\n",
+    "# raw_output : parent is Y\n",
+    "parents = {\n",
+    "    \"A\": [], \"B\": [], \"C\": [],\n",
+    "    \"A+B\": [\"A\", \"B\"],\n",
+    "    \"C\\'\": [\"C\"],\n",
+    "    \"Y\": [\"A+B\", \"C\\'\"],\n",
+    "    \"raw_input\": [\"A\", \"B\", \"C\"],\n",
+    "    \"raw_output\": [\"Y\"]\n",
+    "}\n",
+    "\n",
+    "######################\n",
+    "# 4. mechanisms      #\n",
+    "######################\n",
+    "# HOW do the variables affect each other?\n",
+    "# A, B, C : provide default values \n",
+    "# A+B : computes A + B mod 10\n",
+    "# C' : copies over the value of C\n",
+    "# Y : computes A+B + C' mod 10 (NOTE: we're using the intermediate variables!)\n",
+    "# raw_input : represents A+B+C as a list\n",
+    "# raw_output : represents Y as an int\n",
+    "mechanisms = {\n",
+    "    \"A\": lambda: random.choice(DIGITS),\n",
+    "    \"B\": lambda: random.choice(DIGITS),\n",
+    "    \"C\": lambda: random.choice(DIGITS),\n",
+    "    \"A+B\": lambda a, b: (a + b) % 10,\n",
+    "    \"C\\'\": lambda c: c,\n",
+    "    \"Y\": lambda a_plus_b, c_: (a_plus_b + c_) % 10,\n",
+    "    \"raw_input\": lambda a, b, c: [a, b, c],\n",
+    "    \"raw_output\": lambda y: y\n",
+    "}\n",
+    "\n",
+    "# put it all together!\n",
+    "causal_model = CausalModel(variables, values, parents, mechanisms, id=\"Hierarchical addition\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d66e821",
+   "metadata": {},
+   "source": [
+    "Let's visualize our causal graph. The arrows show which variables have a direct causal effect on each other. If we can take a path from variable $\\alpha$ to variable $\\beta$, then we can say that $\\alpha$ _has a causal effect on_ $\\beta$. That is, changing the value of $\\alpha$ may change the value of $\\beta$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e01f9c00",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x252f2be7940>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "causal_model.display_structure()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "002b88b8",
+   "metadata": {},
+   "source": [
+    "We can pass inputs into our causal model and **run it \"forward\"** to simulate the algorithm's final output - as well as its intermediate values.\n",
+    "\n",
+    "In our visualization, we represent inputs as dark teal nodes, and the intermediate/output values as light teal nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7f7f461c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x252f2f5fe20>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# play around with different inputs!\n",
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "\n",
+    "causal_model.display_forward_pass(inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaba3d86",
+   "metadata": {},
+   "source": [
+    "We can represent any causal process in a causal graph - including neural networks!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e8f7dc91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "l1 = torch.nn.Linear(3, 3)\n",
+    "l2 = torch.nn.Linear(3, 3)\n",
+    "l3 = torch.nn.Linear(3, 1)\n",
+    "\n",
+    "variables = [\n",
+    "    'A', 'B', 'C',\n",
+    "    *[f'h1{i+1}' for i in range(3)],\n",
+    "    *[f'h2{i+1}' for i in range(3)],\n",
+    "    'h31',\n",
+    "    'raw_input',\n",
+    "    'raw_output'\n",
+    "]\n",
+    "\n",
+    "values = {var: None for var in variables}\n",
+    "\n",
+    "parents = {\n",
+    "    'A': [], 'B': [], 'C': [],\n",
+    "    **{f'h1{i+1}': ['A', 'B', 'C'] for i in range(3)},\n",
+    "    **{f'h2{i+1}': ['h11', 'h12', 'h13'] for i in range(3)},\n",
+    "    'h31': ['h21', 'h22', 'h23'],\n",
+    "    \"raw_input\": [\"A\", \"B\", \"C\"],\n",
+    "    \"raw_output\": [\"h31\"]\n",
+    "}\n",
+    "\n",
+    "mechanisms = {\n",
+    "    **{f'h1{i+1}': lambda a, b, c: l1(torch.FloatTensor([a, b, c])).round()[i].item() for i in range(3)},\n",
+    "    **{f'h2{i+1}': lambda h11, h12, h13: l2(torch.FloatTensor([h11, h12, h13])).round()[i].item() for i in range(3)},\n",
+    "    'h31': lambda h21, h22, h23: l3(torch.FloatTensor([h21, h22, h23])).round().item(),\n",
+    "    \"A\": lambda: random.choice(DIGITS),\n",
+    "    \"B\": lambda: random.choice(DIGITS),\n",
+    "    \"C\": lambda: random.choice(DIGITS),\n",
+    "    \"raw_input\": lambda a, b, c: [a, b, c],\n",
+    "    \"raw_output\": lambda y: y\n",
+    "}\n",
+    "\n",
+    "neural_network = CausalModel(variables, values, parents, mechanisms, id=\"Hierarchical addition\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9d11c78c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x252f2f7a2e0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "neural_network.display_structure()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dfc5cd1",
+   "metadata": {},
+   "source": [
+    "Keep this in mind - we'll come back to the idea of representing neural networks as causal models soon! For now, let's see what we can actually do with a causal graph."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "510a4433",
+   "metadata": {},
+   "source": [
+    "## Operations on causal graphs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2414e703",
+   "metadata": {},
+   "source": [
+    "Now that we know what a causal model looks like, let's try playing around with it. The key operation we can perform on a causal graph is an **intervention**. When we perform an intervention, we **change the value of a variable** - this might have downstream effects on the model's computation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eff70095",
+   "metadata": {},
+   "source": [
+    "### Intervening on a causal graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73cc2997",
+   "metadata": {},
+   "source": [
+    "For example, what if the model thought that 1 + 2 was actually 4 instead of 3?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e267fdbf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x252887f0490>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "# let's make the model think that 1 + 2 is 4!\n",
+    "intervention = {'A+B': 4}\n",
+    "\n",
+    "# we \"run the model forward\" again, \n",
+    "# but this time with an intervention changing A + B to 4\n",
+    "causal_model.display_forward_pass(inputs, intervention=intervention)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9c0deea",
+   "metadata": {},
+   "source": [
+    "As you might have predicted, the causal model's new answer is 7 instead of 6. \n",
+    "\n",
+    "*Visualization note: We color the intervention in dark magenta and the values it affects in either light magenta (if the intervention directly affected the value) or violet (if the value was caused by a mix of intervened and base values).*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71504de4",
+   "metadata": {},
+   "source": [
+    "We can choose any variable to intervene on! For example, we can intervene directly on the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1bbf0b6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x25286df0190>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "# let's make the model think that the answer is 10\n",
+    "intervention = {'Y': 10}\n",
+    "\n",
+    "causal_model.display_forward_pass(inputs, intervention=intervention)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90098a73",
+   "metadata": {},
+   "source": [
+    "*Visualization note: since the `raw_output` only depends on the value of the intervened variable (and not the base inputs) we color it in magenta instead of violet.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f52f8700",
+   "metadata": {},
+   "source": [
+    "We can also intervene on parts of the input. For example, let's change just the value of the variable `C` in the input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9521388c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x25288858dc0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "# let's replace the input C with 9\n",
+    "intervention = {'C': 9}\n",
+    "\n",
+    "causal_model.display_forward_pass(inputs, intervention=intervention)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41b084a0",
+   "metadata": {},
+   "source": [
+    "Of course, we could've simulated the model's output by just plugging in 9 for C. But the causal model still plays an important role here - it predicts what each intermediate value will turn out!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50d96580",
+   "metadata": {},
+   "source": [
+    "We can also intervene on multiple variables at the same time. For example, let's see what happens when we set `A + B` to 8 and `C'` to 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "17ac134a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x252888776d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "# let's intervene on all of the intermediate variables\n",
+    "intervention = {'A+B': 8, 'C\\'': 4}\n",
+    "\n",
+    "causal_model.display_forward_pass(inputs, intervention=intervention)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cbd85ce",
+   "metadata": {},
+   "source": [
+    "At this point, we overrode the effects of the inputs! Nevertheless, we have a prediction of what the final output will be, given our interventions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e7c9bc0",
+   "metadata": {},
+   "source": [
+    "### Interchange interventions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11c746be",
+   "metadata": {},
+   "source": [
+    "Interventions are powerful when we know the intermediate values of our causal model. However, in the case of complex systems such as neural networks, the intermediate values might not be predictable or interpretable. For example, it's hard to predict a reasonable value for an MLP activation.\n",
+    "\n",
+    "A very powerful operation we can perform on causal models is an **interchange intervention**. In an interchange intervention, we **don't specify intermediate *values***. Instead, we choose a **set of inputs for the variable we want to change**, and let the causal model **infer** the intermediate value from those causal variables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e2acd1",
+   "metadata": {},
+   "source": [
+    "For example, let's change the model to think that `A + B` is 4 again. This time, we won't specify 4 up front. Instead, we'll **get the value for `A + B`** from running a **separate forward pass** on the inputs `A = 3` and `B = 1`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x25288899e20>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "\n",
+    "# let's change the value of A + B to be 3 + 1!\n",
+    "counterfactual_inputs = {\n",
+    "    'A+B': {'A': 3, 'B': 1, 'C': 3}, \n",
+    "}\n",
+    "\n",
+    "causal_model.display_interchange(inputs, counterfactual_inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18cce369",
+   "metadata": {},
+   "source": [
+    "The result is the same as intervening on `A + B` directly and setting it to 4. But this time around, we didn't need to \"magically\" come up with the number 4 - instead, it came from the model's evaluation on a separate set of inputs. By **interchanging** the value of a variable across two separate forward passes of our causal model, we can estimate its **counterfactual behavior** when we edit the value of one of its variables. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c3c8101",
+   "metadata": {},
+   "source": [
+    "*Side note: just like with interventions, we can perform an interchange intervention on multiple variables! For each variable, we can specify a different source input that will specify its value.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "79d37759",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"650\"\n",
+       "            src=\"http://127.0.0.1:8050/\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "            \n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x2528887eee0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "inputs = {'A': 1, 'B': 2, 'C': 3}\n",
+    "\n",
+    "# let's change the value of A + B and C' using different sources\n",
+    "counterfactual_inputs = {\n",
+    "    'A+B': {'A': 3, 'B': 1, 'C': 3}, # make A + B = 3 + 1\n",
+    "    'C\\'': {'A': 1, 'B': 2, 'C': 8}, # make C' = 8\n",
+    "}\n",
+    "\n",
+    "causal_model.display_interchange(inputs, counterfactual_inputs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "abstraction",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.23"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ jupyterlab
 ipycytoscape
 seaborn
 transformers
+dash
+dash-cytoscape


### PR DESCRIPTION
This PR introduces three visualization functions to `causal_model.py`:
* `display_structure` - displays model structure without inputs
* `display_forward_pass` - displays forward pass of model with base input and (optional) intervention
* `display_interchange` - displays interchange intervention between base input and counterfactual input(s)

The PR also includes a demo notebook for visualizing/understanding causal models through a toy arithmetic example.