### PR TITLE
N2 — component-aware engine routing + --engine

### DIFF
--- a/causalab/cli.py
+++ b/causalab/cli.py
@@ -28,7 +28,7 @@ from causalab.protocol.errors import ProtocolError
 from causalab.protocol.resolve import FileArtifacts, FileDatasets, ResolutionEnv
 from causalab.protocol.schema import PRECISION_DTYPES
 
-__all__ = ["ensure_model_registered", "main", "register_model_key"]
+__all__ = ["ensure_model_registered", "load_engines", "main", "register_model_key"]
 
 
 def _parse_set(values: Sequence[str]) -> dict[str, Any]:
@@ -120,6 +120,15 @@ def _build_parser() -> argparse.ArgumentParser:
                 "(cpu, cuda, cuda:1, mps)",
             )
             p.add_argument(
+                "--engine",
+                choices=("pytorch_hooks", "nnsight", "auto"),
+                default="pytorch_hooks",
+                help="execution engine: the reference (default), the nnsight "
+                "tracing engine (needs the 'nnsight' extra), or 'auto' — "
+                "every installed engine, reference first, routed by "
+                "choose_engine (§8)",
+            )
+            p.add_argument(
                 "--dtype",
                 choices=PRECISION_DTYPES,
                 default=None,
@@ -143,6 +152,43 @@ def _env(args: argparse.Namespace) -> ResolutionEnv:
         datasets=FileDatasets(root=args.data_root),
         artifacts=FileArtifacts(root=args.artifacts_root),
     )
+
+
+def load_engines(choice: str, device: str) -> list[Any]:
+    """Build the ``run`` verb's engine list — lazily, so the pure verbs stay
+    torch-free (importlib keeps the layering honest: ``protocol/`` never
+    links against an execution engine).
+
+    ``auto`` is every installed engine with the reference first — list order
+    is routing preference (§8), so pytorch_hooks serves what it can and the
+    nnsight engine picks up what it refuses. A missing optional engine is
+    only an error when named explicitly."""
+    import importlib
+
+    engines: list[Any] = []
+    if choice in ("pytorch_hooks", "auto"):
+        try:
+            hooks = importlib.import_module("causalab.neural.engines.pytorch_hooks")
+        except ModuleNotFoundError as err:
+            raise ProtocolError(
+                "P2",
+                f"no execution engine available ({err}) — 'run' needs the "
+                "reference engine causalab.neural.engines.pytorch_hooks",
+            ) from err
+        engines.append(hooks.PytorchHooksEngine(device=device))
+    if choice in ("nnsight", "auto"):
+        try:
+            tracing = importlib.import_module("causalab.neural.engines.nnsight_tracing")
+        except ModuleNotFoundError as err:
+            if choice == "nnsight":
+                raise ProtocolError(
+                    "P2",
+                    f"the nnsight engine is not installed ({err}) — install "
+                    "the 'nnsight' extra (pip install 'causalab[nnsight]')",
+                ) from err
+        else:
+            engines.append(tracing.NnsightEngine(device=device))
+    return engines
 
 
 def ensure_model_registered(args: argparse.Namespace) -> None:

--- a/causalab/neural/engines/pytorch_hooks/engine.py
+++ b/causalab/neural/engines/pytorch_hooks/engine.py
@@ -37,6 +37,7 @@ from causalab.protocol.engine import Engine, ExecutionRequest, RunResult
 from causalab.protocol.canonical import canonical_model
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.schema import (
+    COMPONENTS,
     METRIC_DOMAINS,
     WHOLE_WINDOW_METRIC_KINDS,
     Document,
@@ -71,6 +72,16 @@ class PytorchHooksEngine(Engine):
             "writable_attention_probs",
         }
     )
+    # The reference engine serves the whole current vocabulary, writes
+    # included. Read-only/swap-only components and stream constraints are
+    # *protocol policy* (the sites.py refusal tables, shared across engines),
+    # not capability gaps: declaring router_logits unwritable here would turn
+    # "a write here reaches nothing, write router_scores instead" into
+    # "try another engine", which is the wrong answer for every engine. A
+    # component this engine cannot serve (a future interior another engine
+    # owns) is simply absent from these sets and routes away by name.
+    components = frozenset(COMPONENTS)
+    writable_components = frozenset(COMPONENTS)
     is_local = True
 
     def __init__(self, *, device: str = "cpu") -> None:

--- a/causalab/protocol/cli.py
+++ b/causalab/protocol/cli.py
@@ -103,24 +103,14 @@ def main(args: argparse.Namespace, env: ResolutionEnv) -> int:
         if args.verb == "explain":
             _explain(loaded)
             return 0
-        # run — the reference engine is an optional, lazily-imported extra
-        # so the pure verbs stay torch-free (importlib keeps the layering
-        # honest: protocol/ never links against an execution engine)
-        import importlib
+        # run — engines are optional, lazily-imported extras so the pure
+        # verbs stay torch-free; --engine picks the list, choose_engine routes
+        from causalab.cli import load_engines
 
-        try:
-            hooks = importlib.import_module("causalab.neural.engines.pytorch_hooks")
-        except ModuleNotFoundError as err:
-            print(
-                f"refused: no execution engine available ({err}) — 'run' needs "
-                "the reference engine causalab.neural.engines.pytorch_hooks",
-                file=sys.stderr,
-            )
-            return 1
         result = _run(
             loaded,
             env,
-            hooks.PytorchHooksEngine(device=args.device),
+            load_engines(getattr(args, "engine", "pytorch_hooks"), args.device),
             args.out,
             points=args.points,
         )
@@ -135,14 +125,14 @@ def main(args: argparse.Namespace, env: ResolutionEnv) -> int:
 def _run(
     loaded: LoadedProtocol,
     env: ResolutionEnv,
-    engine: Any,
+    engines: list[Any],
     out: Path,
     *,
     points: str | None = None,
 ) -> Any:
     from causalab.protocol.engine import ExecutionRequest, choose_engine
 
-    chosen = choose_engine(list(loaded.point_documents), [engine])
+    chosen = choose_engine(list(loaded.point_documents), engines)
     # --points slices every per-point tuple in lockstep; the campaign
     # digest is untouched — a shard's artifacts still stamp and dedup as
     # members of the whole campaign, so an external scheduler can fan

--- a/causalab/protocol/engine.py
+++ b/causalab/protocol/engine.py
@@ -27,11 +27,16 @@ __all__ = [
     "ExecutionRequest",
     "RunResult",
     "choose_engine",
+    "component_capability",
     "requires",
     "requires_campaign",
 ]
 
-#: The closed capability vocabulary (§8).
+#: The closed capability vocabulary (§8). Component capabilities
+#: (``component:<name>``, ``component:<name>:write``) are *generated*, one per
+#: entry of the closed :data:`~causalab.protocol.schema.Component` vocabulary —
+#: two engines with different site surfaces route on them, and the vocabulary
+#: stays closed because ``Component`` already is.
 CAPABILITIES: tuple[str, ...] = (
     "grad",
     "paired_forward",
@@ -41,6 +46,13 @@ CAPABILITIES: tuple[str, ...] = (
     "generate",
     "quantized_weights",
 )
+
+
+def component_capability(component: str, *, write: bool = False) -> str:
+    """The generated capability entry for serving ``component`` (§8) —
+    reading it, or with ``write=True``, landing a write on it."""
+    return f"component:{component}:write" if write else f"component:{component}"
+
 
 #: Metric kinds that need the whole vocabulary materialized (§8) — but only
 #: when their read actually taps ``lm_head``. ``class_probs`` always does
@@ -72,10 +84,24 @@ def _metric_read_obliges_full_projection(doc: Document, metric: MetricSpec) -> b
 
 def requires(doc: Document) -> frozenset[str]:
     """The capability set one concrete document needs — derived, never
-    authored (§6)."""
+    authored (§6).
+
+    Component needs are part of the set: every site a read or write
+    references contributes ``component:<name>`` (writes also
+    ``component:<name>:write``), so a document is routed by *what it touches*,
+    not only by the coarse §8 verbs — the honest answer once two engines with
+    different site surfaces exist. Stream- and layer-level constraints stay
+    engine-internal: they depend on the loaded model, which routing never
+    sees."""
     needed: set[str] = set()
     if doc.train is not None:
         needed.add("grad")
+    for read in doc.reads.values():
+        needed.add(component_capability(doc.sites[str(read.site)].component))
+    for write in doc.writes.values():
+        component = doc.sites[str(write.site)].component
+        needed.add(component_capability(component))
+        needed.add(component_capability(component, write=True))
     if doc.model.quantization is not None:
         needed.add("quantized_weights")
     for im in doc.intervened_models.values():
@@ -157,8 +183,25 @@ class Engine(abc.ABC):
     name: str = "abstract"
     #: The §8 capability set this engine supports.
     capabilities: frozenset[str] = frozenset()
+    #: Components this engine's site resolver serves. The matching
+    #: ``component:<name>`` capabilities are generated (never listed in
+    #: ``capabilities`` by hand), so the closed vocabulary stays
+    #: :data:`~causalab.protocol.schema.Component`.
+    components: frozenset[str] = frozenset()
+    #: The subset of ``components`` this engine can land a write on.
+    writable_components: frozenset[str] = frozenset()
     #: Local engines may run ``pytorch_fn`` writes (§2.8).
     is_local: bool = False
+
+    @property
+    def effective_capabilities(self) -> frozenset[str]:
+        """``capabilities`` plus the generated component entries — what
+        routing actually compares against :func:`requires`."""
+        return (
+            self.capabilities
+            | {component_capability(c) for c in self.components}
+            | {component_capability(c, write=True) for c in self.writable_components}
+        )
 
     @abc.abstractmethod
     def execute(self, request: ExecutionRequest) -> RunResult:
@@ -183,7 +226,7 @@ def choose_engine(
     needed = requires(doc) if isinstance(doc, Document) else requires_campaign(doc)
     shortfalls: list[str] = []
     for engine in engines:
-        missing = needed - engine.capabilities
+        missing = needed - engine.effective_capabilities
         if not missing:
             return engine
         shortfalls.append(f"{engine.name} lacks {sorted(missing)}")

--- a/causalab/workflow/cli.py
+++ b/causalab/workflow/cli.py
@@ -125,25 +125,16 @@ def main(args: argparse.Namespace, env: ResolutionEnv) -> int:
             for item in loaded.unchecked_paths:
                 print(f"  {item}")
         return 0
-    # run
-    import importlib
-
-    try:
-        hooks = importlib.import_module("causalab.neural.engines.pytorch_hooks")
-    except ModuleNotFoundError as err:
-        print(
-            f"refused: no execution engine available ({err}) — 'run' needs "
-            "the reference engine causalab.neural.engines.pytorch_hooks",
-            file=sys.stderr,
-        )
-        return 1
+    # run — engines are optional, lazily-imported extras; --engine picks
+    # the list, choose_engine routes per protocol step
+    from causalab.cli import load_engines
     from causalab.workflow import run_workflow
 
     result = run_workflow(
         loaded,
         env,
         args.out,
-        [hooks.PytorchHooksEngine(device=args.device)],
+        load_engines(getattr(args, "engine", "pytorch_hooks"), args.device),
         resume=getattr(args, "resume", False),
         reuse_nondeterministic=getattr(args, "reuse_nondeterministic", False),
     )

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -822,6 +822,18 @@ at file level, as before.
 what it supports; `choose_engine = first b where requires ⊆ b.capabilities`;
 refusal messages generate from the missing capability.
 
+Two kinds of entry, one comparison. The **coarse verbs** below are the closed
+`CAPABILITIES` vocabulary. **Component entries** are generated, never listed:
+every site a read or write references contributes `component:<name>` (a write
+also `component:<name>:write`), and each engine declares the component sets it
+serves — so a document touching a component outside one engine's site
+vocabulary routes past it to an engine that serves it, and the generated
+refusal names the entry. The closed vocabulary behind these entries is the
+sec. 2.4 `Component` literal itself. Stream- and layer-level constraints (a
+full-attention box on a DeltaNet layer, a read-only component) stay
+engine-internal policy: they depend on the loaded model or are true of every
+engine, so routing on them would be either impossible or misleading.
+
 | capability | required when |
 |---|---|
 | `grad` | `train` present |
@@ -831,6 +843,7 @@ refusal messages generate from the missing capability.
 | `quantized_weights` | `model.quantization` present (sec. 2.1) |
 | `writable_attention_probs` | a write targets `attention_probs` |
 | `pytorch_fn_local` | any `pytorch_fn` |
+| `component:<name>`[`:write`] | generated — a read or write references a site with that component (writes add `:write`) |
 
 Reference matrix:
 

--- a/tests/protocol/test_cli.py
+++ b/tests/protocol/test_cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from causalab.cli import main
+from causalab.protocol.engine import Engine
+from causalab.protocol.schema import COMPONENTS
 from causalab.protocol.loader import check_data_columns, load
 
 from tests.protocol._env import CORPUS_DIR, FIXTURES
@@ -106,7 +108,7 @@ def test_refusal_exits_nonzero(capsys, artifacts_root):
 # --------------------------------------------------------------------------- #
 
 
-class _CapturingEngine:
+class _CapturingEngine(Engine):
     """Stands in for the reference engine: records construction kwargs and
     the ExecutionRequest, executes nothing."""
 
@@ -116,6 +118,8 @@ class _CapturingEngine:
     capabilities = frozenset(
         {"grad", "paired_forward", "full_logits", "pytorch_fn_local"}
     )
+    components = frozenset(COMPONENTS)
+    writable_components = frozenset(COMPONENTS)
     is_local = True
 
     def __init__(self, *, device: str = "cpu") -> None:
@@ -171,6 +175,31 @@ def test_device_goes_to_the_engine_and_dtype_goes_to_the_document(
     assert not hasattr(capturing_engine.last, "dtype")
     request = capturing_engine.last.request
     assert request.canonical[0]["model"]["dtype"] == "bf16"
+
+
+def test_engine_auto_tolerates_a_missing_optional_engine(
+    capturing_engine, artifacts_root, tmp_path
+):
+    """--engine auto is every *installed* engine: the nnsight extra being
+    absent must not break runs that never needed it."""
+    code = main(
+        _run_argv("01_harvest_im.json", artifacts_root, tmp_path, "--engine", "auto")
+    )
+    assert code == 0
+    assert capturing_engine.last is not None
+
+
+def test_engine_nnsight_refuses_by_name_when_not_installed(
+    capturing_engine, artifacts_root, tmp_path, capsys
+):
+    """Naming an engine that is not installed is an error that says which
+    extra provides it — unlike auto, which quietly narrows to what exists."""
+    code = main(
+        _run_argv("01_harvest_im.json", artifacts_root, tmp_path, "--engine", "nnsight")
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "nnsight" in err and "extra" in err
 
 
 def test_run_defaults_stay_cpu_fp32(capturing_engine, artifacts_root, tmp_path):

--- a/tests/protocol/test_corpus.py
+++ b/tests/protocol/test_corpus.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from causalab.protocol.engine import requires
+from causalab.protocol.engine import component_capability, requires
 from causalab.protocol.loader import load
 from causalab.protocol.plan import closure_digest, plan_point
 
@@ -25,20 +25,90 @@ from tests.protocol._env import CORPUS_DIR
 PINS_PATH = Path(__file__).parent / "corpus_digests.json"
 PINS = json.loads(PINS_PATH.read_text())
 
-#: (file, expected points, expected forwards per point, expected requires)
+
+def _touch(*components: str) -> set[str]:
+    """The generated capability entries for touched components — a trailing
+    ``+w`` marks one the document also writes (§8, component routing)."""
+    needed: set[str] = set()
+    for item in components:
+        name, wrote = (item[:-2], True) if item.endswith("+w") else (item, False)
+        needed.add(component_capability(name))
+        if wrote:
+            needed.add(component_capability(name, write=True))
+    return needed
+
+
+#: (file, expected points, expected forwards per point, expected requires —
+#: coarse capabilities plus the generated component entries)
 CORPUS_SHAPE = [
-    ("01_harvest_im.json", 1, 1, set()),
-    ("02_interchange_im.json", 1, 2, {"paired_forward"}),
-    ("03_path_patching_im.json", 1, 4, {"paired_forward"}),
-    ("04_das_im.json", 1, 2, {"grad", "paired_forward"}),
-    ("05_dbm_im.json", 1, 2, {"grad", "paired_forward"}),
-    ("06_hydra_effect_im.json", 1, 7, {"paired_forward"}),
-    ("07_weekdays_locate_scan_im.json", 64, 2, {"paired_forward"}),
-    ("08_weekdays_das_sweep_im.json", 9, 2, {"grad", "paired_forward"}),
-    ("09_das_apply_im.json", 1, 2, {"paired_forward"}),
-    ("10_task_table_iia_im.json", 1, 3, {"full_logits", "paired_forward"}),
-    ("11_probe_generate_im.json", 1, 1, {"generate", "full_logits"}),
-    ("12_probe_variable_im.json", 1, 1, {"generate", "full_logits"}),
+    ("01_harvest_im.json", 1, 1, _touch("block_output")),
+    (
+        "02_interchange_im.json",
+        1,
+        2,
+        {"paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "03_path_patching_im.json",
+        1,
+        4,
+        {"paired_forward"}
+        | _touch("attention_output+w", "attention_value+w", "block_input+w", "lm_head"),
+    ),
+    (
+        "04_das_im.json",
+        1,
+        2,
+        {"grad", "paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "05_dbm_im.json",
+        1,
+        2,
+        {"grad", "paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "06_hydra_effect_im.json",
+        1,
+        7,
+        {"paired_forward"} | _touch("attention_output+w", "block_output+w", "lm_head"),
+    ),
+    (
+        "07_weekdays_locate_scan_im.json",
+        64,
+        2,
+        {"paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "08_weekdays_das_sweep_im.json",
+        9,
+        2,
+        {"grad", "paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "09_das_apply_im.json",
+        1,
+        2,
+        {"paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "10_task_table_iia_im.json",
+        1,
+        3,
+        {"full_logits", "paired_forward"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "11_probe_generate_im.json",
+        1,
+        1,
+        {"generate", "full_logits"} | _touch("block_output+w", "lm_head"),
+    ),
+    (
+        "12_probe_variable_im.json",
+        1,
+        1,
+        {"generate", "full_logits"} | _touch("block_output", "lm_head"),
+    ),
 ]
 
 

--- a/tests/protocol/test_engine_routing.py
+++ b/tests/protocol/test_engine_routing.py
@@ -9,10 +9,11 @@ from causalab.protocol.engine import (
     ExecutionRequest,
     RunResult,
     choose_engine,
+    component_capability,
     requires,
 )
 from causalab.protocol.errors import ValidationError
-from causalab.protocol.schema import parse_document
+from causalab.protocol.schema import COMPONENTS, parse_document
 
 from tests.protocol._docs import base_doc, in_order
 
@@ -20,25 +21,58 @@ pytestmark = pytest.mark.unit
 
 
 class _Stub(Engine):
-    def __init__(self, name: str, capabilities: frozenset[str], is_local: bool = False):
+    """Coarse-capability stub: serves the whole component vocabulary, so the
+    capability-routing tests below vary only the §8 verbs."""
+
+    def __init__(
+        self,
+        name: str,
+        capabilities: frozenset[str],
+        is_local: bool = False,
+        components: frozenset[str] = frozenset(COMPONENTS),
+        writable_components: frozenset[str] = frozenset(COMPONENTS),
+    ):
         self.name = name
         self.capabilities = capabilities
         self.is_local = is_local
+        self.components = components
+        self.writable_components = writable_components
 
     def execute(self, request: ExecutionRequest) -> RunResult:  # pragma: no cover
         raise NotImplementedError
 
 
+#: base_doc touches block_output (read + write) and lm_head (read).
+BASE_COMPONENTS = frozenset(
+    {
+        component_capability("block_output"),
+        component_capability("block_output", write=True),
+        component_capability("lm_head"),
+    }
+)
+
+
 def test_requires_paired_forward():
     doc = parse_document(base_doc())
-    assert requires(doc) == frozenset({"paired_forward"})
+    assert requires(doc) == frozenset({"paired_forward"}) | BASE_COMPONENTS
 
 
-def test_requires_empty_for_same_input_patching():
+def test_requires_component_entries_split_read_from_write():
+    """Every touched site contributes its component; a written site also
+    contributes the :write entry — the honest routing surface once two
+    engines with different site vocabularies exist (§8)."""
+    doc = parse_document(base_doc())
+    needed = requires(doc)
+    assert component_capability("block_output", write=True) in needed
+    assert component_capability("lm_head") in needed
+    assert component_capability("lm_head", write=True) not in needed
+
+
+def test_requires_no_coarse_verbs_for_same_input_patching():
     raw = base_doc()
     raw["reads"]["v_cf"]["input"] = "base"
     del raw["data"]["counterfactual"]
-    assert requires(parse_document(raw)) == frozenset()
+    assert requires(parse_document(raw)) == BASE_COMPONENTS
 
 
 def test_requires_full_logits_when_lm_head_read_saved():
@@ -164,3 +198,39 @@ def test_an_engine_without_generate_refuses_with_the_capability_named():
     assert "generate" in str(err.value)
     decoder = _Stub("decoder", prefill_only.capabilities | {"generate"})
     assert choose_engine(doc, [prefill_only, decoder]) is decoder
+
+
+def test_an_engine_without_the_component_refuses_by_name():
+    """A document touching a component outside an engine's site vocabulary
+    routes past it, and the generated refusal names the component entry —
+    this is how interior components an engine cannot serve route to the one
+    that can, with no hand-written case anywhere."""
+    doc = parse_document(base_doc())
+    verbs = frozenset({"paired_forward", "full_logits"})
+    no_blocks = _Stub(
+        "no_blocks",
+        verbs,
+        components=frozenset({"lm_head"}),
+        writable_components=frozenset(),
+    )
+    with pytest.raises(ValidationError) as err:
+        choose_engine(doc, [no_blocks])
+    message = str(err.value)
+    assert component_capability("block_output") in message
+    assert component_capability("block_output", write=True) in message
+    full = _Stub("full", verbs)
+    assert choose_engine(doc, [no_blocks, full]) is full
+
+
+def test_a_read_only_component_declaration_refuses_the_write():
+    """components without writable_components serves reads but routes a
+    write away."""
+    doc = parse_document(base_doc())
+    read_only = _Stub(
+        "read_only",
+        frozenset({"paired_forward", "full_logits"}),
+        writable_components=frozenset(),
+    )
+    with pytest.raises(ValidationError) as err:
+        choose_engine(doc, [read_only])
+    assert component_capability("block_output", write=True) in str(err.value)


### PR DESCRIPTION
Stacked on #56 (N1). Plan: cockpit `notes/causalab-nnsight-engine-plan.md` §2.2 / §6-N2, decision D2.

`requires()` now derives `component:<name>` (and `component:<name>:write`) for every site a read/write references; engines declare `components` / `writable_components`, and `choose_engine` compares against `effective_capabilities` = coarse verbs + generated component entries. The closed vocabulary behind the generated entries is `schema.Component` itself. Refusals stay generated and name the missing entry.

`PytorchHooksEngine` declares the full current vocabulary including writes — read-only/swap-only components and stream constraints are shared protocol *policy* (sites.py refusal tables) rather than capability gaps, so their rich refusals stay in place for every engine.

CLI: `--engine {pytorch_hooks,nnsight,auto}` on `run` (default unchanged); `causalab.cli.load_engines` builds the list lazily so the pure verbs stay torch-free. `auto` = every installed engine, reference first (list order is routing preference); a missing optional engine errors only when named explicitly.

Gates: full suite 1968 passed (`-m "not golden"`), corpus digests **zero diff**, pre-commit clean. The corpus table's `requires` pins now spell out each example's component entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)