### PR TITLE
One runnable protocol per method, on the hybrid A3B tower

### DIFF
--- a/causalab/configs/data/weekdays/build.py
+++ b/causalab/configs/data/weekdays/build.py
@@ -1,0 +1,43 @@
+"""Emit the weekdays tables. Fully enumerated, so there is no seed to record:
+7 base days x the counterfactual offsets assigned to each split."""
+
+import json
+import sys
+import pathlib
+
+DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+TEMPLATE = "If today is {day}, tomorrow is"
+
+
+def rows(offsets):
+    out = []
+    for k in offsets:
+        for i, day in enumerate(DAYS):
+            cf_day = DAYS[(i + k) % 7]
+            out.append(
+                {
+                    "input": TEMPLATE.format(day=day),
+                    "counterfactual_inputs": [TEMPLATE.format(day=cf_day)],
+                    "answer": " " + DAYS[(i + 1) % 7],
+                    "base_answer": " " + DAYS[(i + 1) % 7],
+                    "cf_answer": " " + DAYS[(i + k + 1) % 7],
+                    "label": " " + DAYS[(i + k + 1) % 7],
+                    # Per-role prompt variables. A bare `subject` column would
+                    # be looked up against BOTH roles' texts and the
+                    # counterfactual names a different day, so a
+                    # {"variable": "subject"} position would refuse on it. The
+                    # `<field>_variables` sibling is the per-role spelling:
+                    # `input_variables` for the base column, and a list for the
+                    # list-valued counterfactual column, indexed the same way
+                    # the field is.
+                    "input_variables": {"subject": day},
+                    "counterfactual_inputs_variables": [{"subject": cf_day}],
+                }
+            )
+    return out
+
+
+root = pathlib.Path(sys.argv[1])
+for name, offsets in (("train", (1, 3)), ("test", (2,))):
+    (root / f"{name}.json").write_text(json.dumps(rows(offsets), indent=2) + "\n")
+    print(name, len(rows(offsets)), "rows")

--- a/causalab/configs/data/weekdays/test.json
+++ b/causalab/configs/data/weekdays/test.json
@@ -1,0 +1,128 @@
+[
+  {
+    "input": "If today is Monday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Wednesday, tomorrow is"
+    ],
+    "answer": " Tuesday",
+    "base_answer": " Tuesday",
+    "cf_answer": " Thursday",
+    "label": " Thursday",
+    "input_variables": {
+      "subject": "Monday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Wednesday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Tuesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Thursday, tomorrow is"
+    ],
+    "answer": " Wednesday",
+    "base_answer": " Wednesday",
+    "cf_answer": " Friday",
+    "label": " Friday",
+    "input_variables": {
+      "subject": "Tuesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Thursday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Wednesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Friday, tomorrow is"
+    ],
+    "answer": " Thursday",
+    "base_answer": " Thursday",
+    "cf_answer": " Saturday",
+    "label": " Saturday",
+    "input_variables": {
+      "subject": "Wednesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Friday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Thursday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Saturday, tomorrow is"
+    ],
+    "answer": " Friday",
+    "base_answer": " Friday",
+    "cf_answer": " Sunday",
+    "label": " Sunday",
+    "input_variables": {
+      "subject": "Thursday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Saturday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Friday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Sunday, tomorrow is"
+    ],
+    "answer": " Saturday",
+    "base_answer": " Saturday",
+    "cf_answer": " Monday",
+    "label": " Monday",
+    "input_variables": {
+      "subject": "Friday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Sunday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Saturday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Monday, tomorrow is"
+    ],
+    "answer": " Sunday",
+    "base_answer": " Sunday",
+    "cf_answer": " Tuesday",
+    "label": " Tuesday",
+    "input_variables": {
+      "subject": "Saturday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Monday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Sunday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Tuesday, tomorrow is"
+    ],
+    "answer": " Monday",
+    "base_answer": " Monday",
+    "cf_answer": " Wednesday",
+    "label": " Wednesday",
+    "input_variables": {
+      "subject": "Sunday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Tuesday"
+      }
+    ]
+  }
+]

--- a/causalab/configs/data/weekdays/train.json
+++ b/causalab/configs/data/weekdays/train.json
@@ -1,0 +1,254 @@
+[
+  {
+    "input": "If today is Monday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Tuesday, tomorrow is"
+    ],
+    "answer": " Tuesday",
+    "base_answer": " Tuesday",
+    "cf_answer": " Wednesday",
+    "label": " Wednesday",
+    "input_variables": {
+      "subject": "Monday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Tuesday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Tuesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Wednesday, tomorrow is"
+    ],
+    "answer": " Wednesday",
+    "base_answer": " Wednesday",
+    "cf_answer": " Thursday",
+    "label": " Thursday",
+    "input_variables": {
+      "subject": "Tuesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Wednesday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Wednesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Thursday, tomorrow is"
+    ],
+    "answer": " Thursday",
+    "base_answer": " Thursday",
+    "cf_answer": " Friday",
+    "label": " Friday",
+    "input_variables": {
+      "subject": "Wednesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Thursday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Thursday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Friday, tomorrow is"
+    ],
+    "answer": " Friday",
+    "base_answer": " Friday",
+    "cf_answer": " Saturday",
+    "label": " Saturday",
+    "input_variables": {
+      "subject": "Thursday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Friday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Friday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Saturday, tomorrow is"
+    ],
+    "answer": " Saturday",
+    "base_answer": " Saturday",
+    "cf_answer": " Sunday",
+    "label": " Sunday",
+    "input_variables": {
+      "subject": "Friday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Saturday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Saturday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Sunday, tomorrow is"
+    ],
+    "answer": " Sunday",
+    "base_answer": " Sunday",
+    "cf_answer": " Monday",
+    "label": " Monday",
+    "input_variables": {
+      "subject": "Saturday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Sunday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Sunday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Monday, tomorrow is"
+    ],
+    "answer": " Monday",
+    "base_answer": " Monday",
+    "cf_answer": " Tuesday",
+    "label": " Tuesday",
+    "input_variables": {
+      "subject": "Sunday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Monday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Monday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Thursday, tomorrow is"
+    ],
+    "answer": " Tuesday",
+    "base_answer": " Tuesday",
+    "cf_answer": " Friday",
+    "label": " Friday",
+    "input_variables": {
+      "subject": "Monday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Thursday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Tuesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Friday, tomorrow is"
+    ],
+    "answer": " Wednesday",
+    "base_answer": " Wednesday",
+    "cf_answer": " Saturday",
+    "label": " Saturday",
+    "input_variables": {
+      "subject": "Tuesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Friday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Wednesday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Saturday, tomorrow is"
+    ],
+    "answer": " Thursday",
+    "base_answer": " Thursday",
+    "cf_answer": " Sunday",
+    "label": " Sunday",
+    "input_variables": {
+      "subject": "Wednesday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Saturday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Thursday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Sunday, tomorrow is"
+    ],
+    "answer": " Friday",
+    "base_answer": " Friday",
+    "cf_answer": " Monday",
+    "label": " Monday",
+    "input_variables": {
+      "subject": "Thursday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Sunday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Friday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Monday, tomorrow is"
+    ],
+    "answer": " Saturday",
+    "base_answer": " Saturday",
+    "cf_answer": " Tuesday",
+    "label": " Tuesday",
+    "input_variables": {
+      "subject": "Friday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Monday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Saturday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Tuesday, tomorrow is"
+    ],
+    "answer": " Sunday",
+    "base_answer": " Sunday",
+    "cf_answer": " Wednesday",
+    "label": " Wednesday",
+    "input_variables": {
+      "subject": "Saturday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Tuesday"
+      }
+    ]
+  },
+  {
+    "input": "If today is Sunday, tomorrow is",
+    "counterfactual_inputs": [
+      "If today is Wednesday, tomorrow is"
+    ],
+    "answer": " Monday",
+    "base_answer": " Monday",
+    "cf_answer": " Thursday",
+    "label": " Thursday",
+    "input_variables": {
+      "subject": "Sunday"
+    },
+    "counterfactual_inputs_variables": [
+      {
+        "subject": "Wednesday"
+      }
+    ]
+  }
+]

--- a/causalab/configs/protocols/qwen3_6_a3b/README.md
+++ b/causalab/configs/protocols/qwen3_6_a3b/README.md
@@ -1,0 +1,72 @@
+# qwen3.6-35b-a3b — a runnable protocol per method
+
+Twelve documents plus one workflow, one per method the Silico causalab
+documents describe, all pointed at
+[`Qwen/Qwen3.6-35B-A3B`](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) and the
+`weekdays` tables in [`../../data/weekdays`](../../data/weekdays).
+
+They exist because the six-step protocol in silico's
+`answer-research-question/` marks each method **Execution: stub** — "the
+science is kept, the invocations aren't". These are the invocations.
+
+```bash
+causalab validate causalab/configs/protocols/qwen3_6_a3b/interchange.json --data \
+    --data-root causalab/configs/data
+causalab run      causalab/configs/protocols/qwen3_6_a3b/interchange.json \
+    --data-root causalab/configs/data --out runs/interchange --device cuda
+causalab run      causalab/configs/workflows/qwen3_6_a3b_weekdays.json \
+    --data-root causalab/configs/data --out runs --device cuda
+```
+
+| document | method it implements | points |
+|---|---|---|
+| `probe.json` | step 2 · probe — greedy decode, no writes | 1 |
+| `logit_lens.json` | step 2 · logit lens (layer × position) | 77 |
+| `locate_scan.json` | step 2 · paired examples / step 4 · locate | 40 |
+| `knockout_head.json` | step 2 · knockout, attention head grid | 160 |
+| `knockout_mlp.json` | step 2 · knockout, MLP bands at width 1 | 40 |
+| `knockout_mlp_band3.json` | step 2 · knockout, one width-3 band | 1 |
+| `harvest.json` | step 2 · PCA's input + the mean-ablation reference | 1 |
+| `head_attribution.json` | round 2's derived per-head `attention_result` | 1 |
+| `interchange.json` | step 4 · the core test | 1 |
+| `control_positive.json` | step 4 · full mediation, must sit at ceiling | 1 |
+| `control_negative.json` | step 4 · a site the variable cannot be at | 1 |
+| `das_sweep.json` | step 4 · DAS over k × seed | 6 |
+| `das_apply.json` | step 4 · the winner on held-out data (workflow-driven) | 1 |
+
+## What the model's shape costs you
+
+`Qwen3.6-35B-A3B` is a **hybrid** tower: `full_attention_interval` is 4, so of
+its 40 layers only **ten** (3, 7, … 39) carry a full-attention mixer and the
+other thirty carry a Gated DeltaNet. Three consequences the documents encode:
+
+- **the attention head grid is 10 × 16, not 40 × 16.** Naming an attention
+  component at a DeltaNet layer is refused with the architectural reason —
+  there is no attention matrix there — not with "not implemented".
+- **`mlp_activation` is not addressable at all.** Every layer is a sparse-MoE
+  block, which has no `act_fn`, so MLP-family knockout goes through
+  `mlp_output`.
+- **KV-space components have two heads, not sixteen** (`num_key_value_heads` is
+  2 against 16 query heads). `head: 5` on `attention_key`,
+  `attention_key_pre_rope` or `attention_value_states` is refused rather than
+  silently yielding an empty slice.
+
+`head_dim` is 256 and decoupled, so `attention_premix`, `attention_z` and
+`attention_query` are 4096 wide — twice `hidden_size`.
+
+## Retargeting
+
+Every document differs from a Llama-shaped one in `model.key` and site
+`layer`s, and nothing else. The one thing that is **not** portable is which
+layers may carry an attention component; that is the hybrid tower's own fact,
+pinned in `tests/protocol/test_shipped_a3b_configs.py`.
+
+## Two places the document layer does not reach
+
+- **A swept band start.** A sweep axis is a field *value*, not a set of table
+  entries, so a width-3 band whose start moves is a dependent axis — spec §3
+  assigns those to a generator that emits the JSON.
+  `knockout_mlp_band3.json` is the shape such a generator emits.
+- **A prompt-frame metric over several positions.** `top_k` reduces exactly one
+  position per example outside the continuation frame, so the logit lens's
+  (layer × position) grid is two swept axes rather than one `pos: "all"` read.

--- a/causalab/configs/protocols/qwen3_6_a3b/README.md
+++ b/causalab/configs/protocols/qwen3_6_a3b/README.md
@@ -14,9 +14,18 @@ causalab validate causalab/configs/protocols/qwen3_6_a3b/interchange.json --data
     --data-root causalab/configs/data
 causalab run      causalab/configs/protocols/qwen3_6_a3b/interchange.json \
     --data-root causalab/configs/data --out runs/interchange --device cuda
+# step 2 as a fan-out, step 4 as a chain
+causalab run      causalab/configs/workflows/qwen3_6_a3b_exploration.json \
+    --data-root causalab/configs/data --out runs --device cuda
 causalab run      causalab/configs/workflows/qwen3_6_a3b_weekdays.json \
     --data-root causalab/configs/data --out runs --device cuda
 ```
+
+The PCA half of step 2 needs no new code: `harvest.json`'s activations feed the
+already-shipped `causalab.analysis.fit_pca` script step, which the exploration
+workflow wires up. ⚠️ It is wired at demo scale — 14 rows against a 2048-wide
+residual is a *shape* demonstration, not a fit. The method wants a few thousand
+inputs; widen `../../data/weekdays` before reading anything into the spectrum.
 
 | document | method it implements | points |
 |---|---|---|

--- a/causalab/configs/protocols/qwen3_6_a3b/control_negative.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/control_negative.json
@@ -1,0 +1,80 @@
+{
+  "version": "1",
+  "description": "Step 4 / negative control: the same interchange at a site the variable cannot be. Position 0 is the prompt's first token ('If'), which under causal attention is computed before the subject is ever read, so a mid-tower transplant there carries no weekday. A method that scores here is measuring something other than the variable.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/train",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "positions": {
+    "prefix": {
+      "index": 0
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": 20
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": "prefix",
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": "prefix",
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "cf_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/control_positive.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/control_positive.json
@@ -1,0 +1,75 @@
+{
+  "version": "1",
+  "description": "Step 4 / positive control: full mediation. Transplanting the whole answer-slot residual at the LAST block leaves only ln_final and the unembedding downstream, so IIA must sit at ceiling. Run it first - if this does not score ~1.0 the pipeline is broken and no other number in the campaign means anything.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/train",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": 39
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": -1,
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "cf_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/das_apply.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/das_apply.json
@@ -1,0 +1,102 @@
+{
+  "version": "1",
+  "description": "Step 4 / DAS apply: evaluate ONE fitted rotation on the held-out split rather than re-fitting it. `file_path` loads the bundle and `entry` names which (k, seed) point of the sweep to apply; the bundle's identity (model, site, k, parametrization, dtype) is checked at load, so a rotation fitted elsewhere refuses instead of silently mis-applying. No train section - a featurizer with file_path may not be trained. Driven by workflow.json, which sets file_path, k and entry from the fit step's winner.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/test",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/test",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": 20
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "featurizers": {
+    "rot": {
+      "kind": "subspace",
+      "k": 8,
+      "parametrization": "cayley",
+      "file_path": "fit/rot.safetensors",
+      "entry": {
+        "k": 8,
+        "seed": 0
+      }
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual",
+      "featurizer": "rot"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": -1,
+      "featurizer": "rot",
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "logit_diff",
+      "of": "logits",
+      "a": "cf_answer",
+      "b": "base_answer",
+      "token_form": "space_prefixed"
+    },
+    "iia_match": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "cf_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    },
+    {
+      "value": "iia_match",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia_match.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/das_sweep.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/das_sweep.json
@@ -1,0 +1,149 @@
+{
+  "version": "1",
+  "description": "Step 4 / DAS fit: learn which subspace of the located cell mediates the variable, over a k x seed grid so the rank is argued from the IIA-vs-k curve and the seed-to-seed spread is visible. Six fits share one harvest - the parser trains all of them against the same collected activations. In the workflow the layer comes from the locate step; standalone it is the mid-tower cell.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/train",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": 20
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "featurizers": {
+    "rot": {
+      "kind": "subspace",
+      "k": {
+        "sweep": [
+          4,
+          8,
+          16
+        ]
+      },
+      "parametrization": "cayley"
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual",
+      "featurizer": "rot"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": -1,
+      "featurizer": "rot",
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "logit_diff",
+      "of": "logits",
+      "a": "cf_answer",
+      "b": "base_answer",
+      "token_form": "space_prefixed"
+    },
+    "ce": {
+      "kind": "cross_entropy",
+      "of": "logits",
+      "target": "label",
+      "token_form": "space_prefixed"
+    }
+  },
+  "train": {
+    "objective": [
+      [
+        1.0,
+        "ce"
+      ]
+    ],
+    "params": [
+      "rot"
+    ],
+    "optimizer": {
+      "name": "adamw",
+      "lr": 0.001,
+      "weight_decay": 0.0
+    },
+    "steps": {
+      "epochs": 8
+    },
+    "batch": {
+      "pairs": 14
+    },
+    "precision": {
+      "feature": "fp32",
+      "loss": "fp32"
+    },
+    "eval": {
+      "every": {
+        "epochs": 2
+      },
+      "split": "weekdays/test",
+      "metrics": [
+        "iia"
+      ]
+    },
+    "seed": {
+      "sweep": [
+        0,
+        1
+      ]
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    },
+    {
+      "value": "ce",
+      "model": "patched",
+      "input": "base",
+      "file_path": "ce.json"
+    },
+    {
+      "value": "rot",
+      "site": "target",
+      "file_path": "rot.safetensors"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/harvest.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/harvest.json
@@ -1,0 +1,102 @@
+{
+  "version": "1",
+  "description": "Step 2 / PCA's input, and the mean reference knockout needs. Pure reads at three depths x two positions, one un-intervened forward, no writes. The `acts_*` files are the (rows, positions, 2048) tensors an offline centered PCA is fitted on. `mean_L20_ans` is the SAME address read a second time and reduced where the rows are gathered - the on-manifold replacement value a mean ablation swaps in. It has to be a second read rather than a second save entry, because the manifest allows one entry per value (rule 10); the two reads are content-identical so the planner interns them and the forward is still run once.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    }
+  },
+  "positions": {
+    "answer_tok": {
+      "index": -1
+    },
+    "subject": {
+      "variable": "subject"
+    }
+  },
+  "sites": {
+    "L8": {
+      "component": "block_output",
+      "layer": 8
+    },
+    "L20": {
+      "component": "block_output",
+      "layer": 20
+    },
+    "L32": {
+      "component": "block_output",
+      "layer": 32
+    }
+  },
+  "reads": {
+    "acts_L8_ans": {
+      "site": "L8",
+      "pos": "answer_tok",
+      "model": "original",
+      "input": "base"
+    },
+    "acts_L20_ans": {
+      "site": "L20",
+      "pos": "answer_tok",
+      "model": "original",
+      "input": "base"
+    },
+    "acts_L32_ans": {
+      "site": "L32",
+      "pos": "answer_tok",
+      "model": "original",
+      "input": "base"
+    },
+    "acts_L20_sub": {
+      "site": "L20",
+      "pos": "subject",
+      "model": "original",
+      "input": "base"
+    },
+    "mean_L20_ans": {
+      "site": "L20",
+      "pos": "answer_tok",
+      "model": "original",
+      "input": "base"
+    }
+  },
+  "save": [
+    {
+      "value": "acts_L8_ans",
+      "model": "original",
+      "input": "base",
+      "file_path": "acts_L8_ans.safetensors"
+    },
+    {
+      "value": "acts_L20_ans",
+      "model": "original",
+      "input": "base",
+      "file_path": "acts_L20_ans.safetensors"
+    },
+    {
+      "value": "acts_L32_ans",
+      "model": "original",
+      "input": "base",
+      "file_path": "acts_L32_ans.safetensors"
+    },
+    {
+      "value": "acts_L20_sub",
+      "model": "original",
+      "input": "base",
+      "file_path": "acts_L20_sub.safetensors"
+    },
+    {
+      "value": "mean_L20_ans",
+      "model": "original",
+      "input": "base",
+      "file_path": "mean_L20_ans.safetensors",
+      "reduce": "mean"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/head_attribution.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/head_attribution.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "description": "Round 2's derived component on the real checkpoint: `attention_result` is each head's own contribution to the residual stream, which the model never forms - it projects the whole premix at once. Read whole (16 heads x 2048 hidden = 32768 wide) at the answer slot, at three full-attention layers, alongside `attention_output` at the same layers. The identity that defines the component is sum_h result == attention_output (this o-projection carries no bias), so these two files are a check as well as a measurement.",
+  "model": {"key": "Qwen/Qwen3.6-35B-A3B", "revision": "main", "dtype": "bf16"},
+  "data": {
+    "base": {"dataset": "weekdays/train", "field": "input"}
+  },
+  "sites": {
+    "result_L3":  {"component": "attention_result", "layer": 3},
+    "result_L19": {"component": "attention_result", "layer": 19},
+    "result_L39": {"component": "attention_result", "layer": 39},
+    "out_L3":     {"component": "attention_output", "layer": 3},
+    "out_L19":    {"component": "attention_output", "layer": 19},
+    "out_L39":    {"component": "attention_output", "layer": 39}
+  },
+  "reads": {
+    "r3":  {"site": "result_L3",  "pos": -1, "model": "original", "input": "base"},
+    "r19": {"site": "result_L19", "pos": -1, "model": "original", "input": "base"},
+    "r39": {"site": "result_L39", "pos": -1, "model": "original", "input": "base"},
+    "o3":  {"site": "out_L3",     "pos": -1, "model": "original", "input": "base"},
+    "o19": {"site": "out_L19",    "pos": -1, "model": "original", "input": "base"},
+    "o39": {"site": "out_L39",    "pos": -1, "model": "original", "input": "base"}
+  },
+  "save": [
+    {"value": "r3",  "model": "original", "input": "base", "file_path": "result_L3.safetensors"},
+    {"value": "r19", "model": "original", "input": "base", "file_path": "result_L19.safetensors"},
+    {"value": "r39", "model": "original", "input": "base", "file_path": "result_L39.safetensors"},
+    {"value": "o3",  "model": "original", "input": "base", "file_path": "attn_out_L3.safetensors"},
+    {"value": "o19", "model": "original", "input": "base", "file_path": "attn_out_L19.safetensors"},
+    {"value": "o39", "model": "original", "input": "base", "file_path": "attn_out_L39.safetensors"}
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/interchange.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/interchange.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "description": "Step 4 / the core test: swap the answer-slot residual stream from the counterfactual into the base at one mid-tower layer, and score IIA. This is configs/protocols/interchange.json retargeted - only model.key and sites.target.layer differ.",
+  "description": "Step 4 / the core test: swap the residual stream from the counterfactual into the base at ONE located cell, and score IIA. The cell is not a guess - locate_scan.json puts the weekday at the subject token from layer 10 onward (IIA 1.000) and at the answer slot only in the last few layers, so this tests the subject token at mid-tower. \ud83d\udcd0 Measured on the checkpoint: IIA 1.000 here, against 0.000 for the same layer at the answer slot, which is what makes 'locate first, then test' a rule rather than advice.",
   "model": {
     "key": "Qwen/Qwen3.6-35B-A3B",
     "revision": "main",
@@ -16,6 +16,11 @@
       "field": "counterfactual_inputs[0]"
     }
   },
+  "positions": {
+    "tap": {
+      "variable": "subject"
+    }
+  },
   "sites": {
     "target": {
       "component": "block_output",
@@ -28,7 +33,7 @@
   "reads": {
     "v_cf": {
       "site": "target",
-      "pos": -1,
+      "pos": "tap",
       "model": "original",
       "input": "counterfactual"
     },
@@ -42,7 +47,7 @@
   "writes": {
     "patch": {
       "site": "target",
-      "pos": -1,
+      "pos": "tap",
       "do": {
         "swap": "v_cf"
       }

--- a/causalab/configs/protocols/qwen3_6_a3b/interchange.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/interchange.json
@@ -1,0 +1,88 @@
+{
+  "version": "1",
+  "description": "Step 4 / the core test: swap the answer-slot residual stream from the counterfactual into the base at one mid-tower layer, and score IIA. This is configs/protocols/interchange.json retargeted - only model.key and sites.target.layer differ.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/train",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": 20
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": -1,
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "cf_answer",
+      "token_form": "space_prefixed"
+    },
+    "logit_diff": {
+      "kind": "logit_diff",
+      "of": "logits",
+      "a": "cf_answer",
+      "b": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    },
+    {
+      "value": "logit_diff",
+      "model": "patched",
+      "input": "base",
+      "file_path": "logit_diff.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/knockout_head.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/knockout_head.json
@@ -1,0 +1,103 @@
+{
+  "version": "1",
+  "description": "Step 2 / knockout, attention family: zero-ablate one attention head's contribution across the whole prompt and measure the damage. sites.attn.layer sweeps ONLY the ten full-attention layers - the other thirty carry a Gated DeltaNet mixer with no head axis at all, and naming one there is refused with the architectural reason, not a missing feature. 10 layers x 16 heads = 160 points. `swap: 0.0` is the zero reference; the on-manifold mean reference is harvest.json's `reduce: mean` output fed back as a params constant.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    }
+  },
+  "positions": {
+    "every": {
+      "all": true
+    }
+  },
+  "sites": {
+    "attn": {
+      "component": "attention_premix",
+      "layer": {
+        "sweep": [
+          3,
+          7,
+          11,
+          15,
+          19,
+          23,
+          27,
+          31,
+          35,
+          39
+        ]
+      },
+      "head": {
+        "sweep": {
+          "range": [
+            0,
+            16
+          ]
+        }
+      }
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "ablated",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "zero": {
+      "site": "attn",
+      "pos": "every",
+      "do": {
+        "swap": 0.0
+      }
+    }
+  },
+  "intervened_models": {
+    "ablated": {
+      "input": "base",
+      "writes": [
+        "zero"
+      ]
+    }
+  },
+  "metrics": {
+    "still_correct": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "base_answer",
+      "token_form": "space_prefixed"
+    },
+    "answer_logit": {
+      "kind": "token_logit",
+      "of": "logits",
+      "token": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "still_correct",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "still_correct.json"
+    },
+    {
+      "value": "answer_logit",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "answer_logit.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/knockout_mlp.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/knockout_mlp.json
@@ -1,0 +1,89 @@
+{
+  "version": "1",
+  "description": "Step 2 / knockout, MLP family at band width 1: zero the MoE block's output at each of the 40 layers in turn. `mlp_output` is the block's combined routed+shared output and is hidden-wide on every layer, so unlike the attention family this scan covers the whole tower. Note that `mlp_activation` is NOT addressable here - a sparse-MoE block has no act_fn, and the tap table refuses it by name.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    }
+  },
+  "positions": {
+    "every": {
+      "all": true
+    }
+  },
+  "sites": {
+    "mlp": {
+      "component": "mlp_output",
+      "layer": {
+        "sweep": {
+          "range": [
+            0,
+            40
+          ]
+        }
+      }
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "ablated",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "zero": {
+      "site": "mlp",
+      "pos": "every",
+      "do": {
+        "swap": 0.0
+      }
+    }
+  },
+  "intervened_models": {
+    "ablated": {
+      "input": "base",
+      "writes": [
+        "zero"
+      ]
+    }
+  },
+  "metrics": {
+    "still_correct": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "base_answer",
+      "token_form": "space_prefixed"
+    },
+    "answer_logit": {
+      "kind": "token_logit",
+      "of": "logits",
+      "token": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "still_correct",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "still_correct.json"
+    },
+    {
+      "value": "answer_logit",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "answer_logit.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/knockout_mlp_band3.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/knockout_mlp_band3.json
@@ -1,0 +1,106 @@
+{
+  "version": "1",
+  "description": "Step 2 / knockout, MLP family at band width 3: layers 18-20 zeroed jointly, to read how the drop grows with width against knockout_mlp.json's width-1 curve. The band is three sites and three writes in one intervened_model because a sweep axis is a field VALUE, not a set of table entries - a swept band START is a dependent axis, which spec 3 assigns to a generator that emits the JSON rather than to the document layer. This file is the shape such a generator emits.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    }
+  },
+  "positions": {
+    "every": {
+      "all": true
+    }
+  },
+  "sites": {
+    "mlp_18": {
+      "component": "mlp_output",
+      "layer": 18
+    },
+    "mlp_19": {
+      "component": "mlp_output",
+      "layer": 19
+    },
+    "mlp_20": {
+      "component": "mlp_output",
+      "layer": 20
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "ablated",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "zero_18": {
+      "site": "mlp_18",
+      "pos": "every",
+      "do": {
+        "swap": 0.0
+      }
+    },
+    "zero_19": {
+      "site": "mlp_19",
+      "pos": "every",
+      "do": {
+        "swap": 0.0
+      }
+    },
+    "zero_20": {
+      "site": "mlp_20",
+      "pos": "every",
+      "do": {
+        "swap": 0.0
+      }
+    }
+  },
+  "intervened_models": {
+    "ablated": {
+      "input": "base",
+      "writes": [
+        "zero_18",
+        "zero_19",
+        "zero_20"
+      ]
+    }
+  },
+  "metrics": {
+    "still_correct": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "base_answer",
+      "token_form": "space_prefixed"
+    },
+    "answer_logit": {
+      "kind": "token_logit",
+      "of": "logits",
+      "token": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "still_correct",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "still_correct.json"
+    },
+    {
+      "value": "answer_logit",
+      "model": "ablated",
+      "input": "base",
+      "file_path": "answer_logit.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/locate_scan.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/locate_scan.json
@@ -1,0 +1,108 @@
+{
+  "version": "1",
+  "description": "Step 2 / paired examples, and step 4's locate stage: the full localization sweep as ONE document. Two explicit axes - sites.target.layer over the 40-block tower at stride 2, and positions.tap over the answer slot and the subject token - cross to 40 points. Every read and write referencing `target` or `tap` moves together, and the counterfactual harvest is shared across all 40 by content dedup.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "weekdays/train",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "positions": {
+    "tap": {
+      "sweep": [
+        {
+          "index": -1
+        },
+        {
+          "variable": "subject"
+        }
+      ]
+    }
+  },
+  "sites": {
+    "target": {
+      "component": "block_output",
+      "layer": {
+        "sweep": {
+          "range": [
+            0,
+            40,
+            2
+          ]
+        }
+      }
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "v_cf": {
+      "site": "target",
+      "pos": "tap",
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "logits": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "patched",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "patch": {
+      "site": "target",
+      "pos": "tap",
+      "do": {
+        "swap": "v_cf"
+      }
+    }
+  },
+  "intervened_models": {
+    "patched": {
+      "input": "base",
+      "writes": [
+        "patch"
+      ]
+    }
+  },
+  "metrics": {
+    "iia": {
+      "kind": "match",
+      "of": "logits",
+      "expected": "cf_answer",
+      "token_form": "space_prefixed"
+    },
+    "logit_diff": {
+      "kind": "logit_diff",
+      "of": "logits",
+      "a": "cf_answer",
+      "b": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "iia",
+      "model": "patched",
+      "input": "base",
+      "file_path": "iia.json"
+    },
+    {
+      "value": "logit_diff",
+      "model": "patched",
+      "input": "base",
+      "file_path": "logit_diff.json"
+    }
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/logit_lens.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/logit_lens.json
@@ -1,0 +1,35 @@
+{
+  "version": "1",
+  "description": "Step 2 / logit lens, expressed with no new primitive. Reading block_output at layer L and swapping it into block_output at the LAST block leaves exactly ln_final and the unembedding downstream - which is the lens by definition. The L=39 point is the identity and must reproduce the model's own prediction. ⚠️ The (layer x position) grid is TWO axes, not one read at pos 'all': a prompt-frame metric reduces exactly one position per example, so `top_k` over a 7-position read is refused. The position is therefore a swept axis, and the 11 x 7 cross is the grid. The transplant itself is still whole-prompt, and the patched forward for a given layer is content-identical across the seven position points, so the planner interns it.",
+  "model": {"key": "Qwen/Qwen3.6-35B-A3B", "revision": "main", "dtype": "bf16"},
+  "data": {
+    "base": {"dataset": "weekdays/train", "field": "input"}
+  },
+  "positions": {
+    "every": {"all": true},
+    "cell":  {"sweep": [{"index": 0}, {"index": 1}, {"index": 2}, {"index": 3}, {"index": 4}, {"index": 5}, {"index": 6}]}
+  },
+  "sites": {
+    "source":  {"component": "block_output", "layer": {"sweep": [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 39]}},
+    "sink":    {"component": "block_output", "layer": 39},
+    "lm_head": {"component": "lm_head"}
+  },
+  "reads": {
+    "resid":   {"site": "source",  "pos": "every", "model": "original", "input": "base"},
+    "lens_at": {"site": "lm_head", "pos": "cell",  "model": "lensed",   "input": "base"}
+  },
+  "writes": {
+    "project": {"site": "sink", "pos": "every", "do": {"swap": "resid"}}
+  },
+  "intervened_models": {
+    "lensed": {"input": "base", "writes": ["project"]}
+  },
+  "metrics": {
+    "top5":    {"kind": "top_k", "of": "lens_at", "k": 5, "by": "prob"},
+    "decodes": {"kind": "match", "of": "lens_at", "expected": "base_answer", "token_form": "space_prefixed"}
+  },
+  "save": [
+    {"value": "top5", "model": "lensed", "input": "base", "file_path": "top5.json"},
+    {"value": "decodes", "model": "lensed", "input": "base", "file_path": "decodes.json"}
+  ]
+}

--- a/causalab/configs/protocols/qwen3_6_a3b/probe.json
+++ b/causalab/configs/protocols/qwen3_6_a3b/probe.json
@@ -1,0 +1,83 @@
+{
+  "version": "1",
+  "description": "Step 2 / probe: greedy-decode four tokens and read them back as text. No writes, so no intervened_models - the whole document is the 'just run these prompts' shape. The `decode` metric is in the `ids` domain, so the run owes no vocabulary projection at all (IM spec 2.10); `top_k` at the first generated position is the answer distribution that produced token 0.",
+  "model": {
+    "key": "Qwen/Qwen3.6-35B-A3B",
+    "revision": "main",
+    "dtype": "bf16"
+  },
+  "data": {
+    "base": {
+      "dataset": "weekdays/train",
+      "field": "input"
+    }
+  },
+  "positions": {
+    "continuation": {
+      "generated": {
+        "max_new_tokens": 4
+      },
+      "all": true
+    },
+    "first_answer": {
+      "index": -1
+    }
+  },
+  "sites": {
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "tail": {
+      "site": "lm_head",
+      "pos": "continuation",
+      "model": "original",
+      "input": "base"
+    },
+    "answer": {
+      "site": "lm_head",
+      "pos": "first_answer",
+      "model": "original",
+      "input": "base"
+    }
+  },
+  "metrics": {
+    "text": {
+      "kind": "decode",
+      "of": "tail"
+    },
+    "top5": {
+      "kind": "top_k",
+      "of": "answer",
+      "k": 5,
+      "by": "prob"
+    },
+    "correct": {
+      "kind": "match",
+      "of": "answer",
+      "expected": "base_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "text",
+      "model": "original",
+      "input": "base",
+      "file_path": "text.json"
+    },
+    {
+      "value": "top5",
+      "model": "original",
+      "input": "base",
+      "file_path": "top5.json"
+    },
+    {
+      "value": "correct",
+      "model": "original",
+      "input": "base",
+      "file_path": "correct.json"
+    }
+  ]
+}

--- a/causalab/configs/workflows/qwen3_6_a3b_exploration.json
+++ b/causalab/configs/workflows/qwen3_6_a3b_exploration.json
@@ -1,0 +1,72 @@
+{
+  "version": "1",
+  "description": "qwen3.6-35b-a3b weekdays, step 2: the exploratory battery as one document - probe, logit lens, the two knockout families, and a harvest whose activations a principal basis is fitted over. Independent steps ARE the parallelism; the only dependency here is harvest -> pca -> spectrum, and the runner derives it.",
+  "output_dir": "qwen3_6_a3b_exploration",
+  "steps": {
+    "probe": {
+      "type": "intervention_protocol",
+      "description": "Confirm the model does the task before spending compute on where.",
+      "document": "../protocols/qwen3_6_a3b/probe.json"
+    },
+    "logit_lens": {
+      "type": "intervention_protocol",
+      "description": "Depth x position: what each cell would predict if the network stopped there.",
+      "document": "../protocols/qwen3_6_a3b/logit_lens.json"
+    },
+    "knockout_attention": {
+      "type": "intervention_protocol",
+      "description": "The (layer x head) grid, over the ten full-attention layers.",
+      "document": "../protocols/qwen3_6_a3b/knockout_head.json"
+    },
+    "knockout_mlp": {
+      "type": "intervention_protocol",
+      "description": "MLP bands at width 1, over the whole tower.",
+      "document": "../protocols/qwen3_6_a3b/knockout_mlp.json"
+    },
+    "harvest": {
+      "type": "intervention_protocol",
+      "description": "Residual stream at three depths, plus the mean-ablation reference.",
+      "document": "../protocols/qwen3_6_a3b/harvest.json"
+    },
+    "pca": {
+      "type": "script",
+      "description": "Centered principal basis over the mid-tower answer-slot activations.",
+      "script": {"module": "causalab.analysis.fit_pca"},
+      "inputs": {
+        "acts": {"step": "harvest", "file": "acts_L20_ans.safetensors"},
+        "k": 8
+      },
+      "outputs": {
+        "weight": "basis_L20.safetensors",
+        "spectrum": {
+          "file": "spectrum_L20.json",
+          "columns": {"pc": "int64", "explained_variance": "float64", "explained_variance_ratio": "float64"}
+        }
+      }
+    },
+    "spectrum": {
+      "type": "script",
+      "description": "How much structure the top components carry, and at what rank it flattens.",
+      "script": {"module": "causalab.io.plots.workflow_figures"},
+      "inputs": {
+        "table": {"step": "pca", "file": "spectrum_L20.json"},
+        "plot": "lines",
+        "value": "explained_variance_ratio",
+        "x": "pc"
+      },
+      "outputs": {"figure": "spectrum_L20.png", "plotted": {"file": "spectrum_L20_plotted.json"}}
+    },
+    "head_grid": {
+      "type": "script",
+      "description": "The knockout grid as a (layer x head) heatmap.",
+      "script": {"module": "causalab.io.plots.workflow_figures"},
+      "inputs": {
+        "table": {"step": "knockout_attention", "file": "answer_logit.json"},
+        "plot": "heatmap",
+        "x": "sites.attn.layer",
+        "y": "sites.attn.head"
+      },
+      "outputs": {"figure": "head_grid.png", "plotted": {"file": "head_grid.json"}}
+    }
+  }
+}

--- a/causalab/configs/workflows/qwen3_6_a3b_weekdays.json
+++ b/causalab/configs/workflows/qwen3_6_a3b_weekdays.json
@@ -1,0 +1,82 @@
+{
+  "version": "1",
+  "description": "qwen3.6-35b-a3b weekdays: the whole hypothesis-testing chain as one document - locate a (layer x position) cell, select the best, fit DAS over k x seed at it, select the winner, apply that winner on the held-out split, and plot both stages. The dependencies are derived from the wiring, not remembered; every step's outputs stay in its own directory.",
+  "output_dir": "qwen3_6_a3b_weekdays",
+  "steps": {
+    "locate": {
+      "type": "intervention_protocol",
+      "description": "40-point layer x position interchange scan.",
+      "document": "../protocols/qwen3_6_a3b/locate_scan.json"
+    },
+    "best": {
+      "type": "script",
+      "description": "The cell with the highest IIA becomes the fit's site and position.",
+      "script": {"module": "causalab.workflow.scripts.select"},
+      "inputs": {
+        "table": {"step": "locate", "file": "iia.json"},
+        "choose": "max",
+        "emit": {"best_layer": "sites.target.layer", "best_pos": "positions.tap"}
+      },
+      "outputs": {
+        "values": {"file": "values.json", "keys": {"best_layer": 20, "best_pos": {"index": -1}}}
+      }
+    },
+    "fit": {
+      "type": "intervention_protocol",
+      "description": "DAS over k x seed at the located cell.",
+      "document": "../protocols/qwen3_6_a3b/das_sweep.json",
+      "set": {
+        "sites.target.layer": {"artifact": "best", "key": "best_layer"}
+      }
+    },
+    "best_fit": {
+      "type": "script",
+      "description": "Pick the rank and seed to carry to held-out data.",
+      "script": {"module": "causalab.workflow.scripts.select"},
+      "inputs": {
+        "table": {"step": "fit", "file": "iia.json"},
+        "choose": "max",
+        "emit": {"best_k": "featurizers.rot.k", "best_seed": "train.seed"}
+      },
+      "outputs": {
+        "values": {"file": "values.json", "keys": {"best_k": 8, "best_seed": 0}}
+      }
+    },
+    "apply": {
+      "type": "intervention_protocol",
+      "description": "Evaluate the winning rotation on weekdays/test.",
+      "document": "../protocols/qwen3_6_a3b/das_apply.json",
+      "set": {
+        "sites.target.layer": {"artifact": "best", "key": "best_layer"},
+        "featurizers.rot.file_path": "fit/rot.safetensors",
+        "featurizers.rot.k": {"artifact": "best_fit", "key": "best_k"},
+        "featurizers.rot.entry": {
+          "k": {"artifact": "best_fit", "key": "best_k"},
+          "seed": {"artifact": "best_fit", "key": "best_seed"}
+        }
+      }
+    },
+    "scan_heatmap": {
+      "type": "script",
+      "script": {"module": "causalab.io.plots.workflow_figures"},
+      "inputs": {
+        "table": {"step": "locate", "file": "iia.json"},
+        "plot": "heatmap",
+        "x": "sites.target.layer",
+        "y": "positions.tap"
+      },
+      "outputs": {"figure": "scan_iia.png", "plotted": {"file": "scan_iia.json"}}
+    },
+    "iia_by_k": {
+      "type": "script",
+      "script": {"module": "causalab.io.plots.workflow_figures"},
+      "inputs": {
+        "table": {"step": "fit", "file": "iia.json"},
+        "plot": "lines",
+        "x": "featurizers.rot.k",
+        "series": "train.seed"
+      },
+      "outputs": {"figure": "iia_by_k.png", "plotted": {"file": "iia_by_k.json"}}
+    }
+  }
+}

--- a/causalab/protocol/registry.py
+++ b/causalab/protocol/registry.py
@@ -495,6 +495,37 @@ register_model(
 )
 register_model(
     ModelInfo(
+        # A hybrid MoE tower: 30 of its 40 layers carry a Gated DeltaNet mixer
+        # and only every 4th (3, 7, ... 39) is full attention, so the attention
+        # vocabulary resolves at ten layers and refuses architecturally at the
+        # rest. `attn_output_gate` is true, which is what makes
+        # `attention_gate` a real component here.
+        key="Qwen/Qwen3.6-35B-A3B",
+        hidden_size=2048,
+        num_layers=40,
+        num_heads=16,
+        # GQA ratio 8 — the KV-space components (`attention_key`,
+        # `attention_key_pre_rope`, `attention_value_states`) have TWO heads,
+        # not sixteen, which is the bound `head_space` exists to enforce.
+        num_kv_heads=2,
+        # decoupled: heads * head_dim = 4096 = 2x hidden_size
+        head_dim=256,
+        # ⚠️ The checkpoint's text_config declares no `intermediate_size` (every
+        # layer is a sparse MoE block; `moe_intermediate_size` is 512). This is
+        # the `4 * hidden` fallback `_intermediate_size` computes, recorded so
+        # the static entry and `model_info_from_hf_config` cannot disagree —
+        # `mlp_activation` refuses at the tap table on this family regardless,
+        # because a sparse-MoE block has no `act_fn`.
+        intermediate_size=8192,
+        vocab_size=248320,
+        native_dtype="bf16",
+        num_experts=256,
+        num_experts_per_tok=8,
+        shared_expert_intermediate_size=512,
+    )
+)
+register_model(
+    ModelInfo(
         key="google/gemma-2-2b-it",
         hidden_size=2304,
         num_layers=26,

--- a/tests/protocol/test_shipped_a3b_configs.py
+++ b/tests/protocol/test_shipped_a3b_configs.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.unit
 
 CONFIGS = Path(__file__).resolve().parents[2] / "causalab" / "configs"
 PROTOCOLS = CONFIGS / "protocols" / "qwen3_6_a3b"
-WORKFLOW = CONFIGS / "workflows" / "qwen3_6_a3b_weekdays.json"
+WORKFLOWS = CONFIGS / "workflows"
 
 #: file stem -> expanded point count. `das_apply` is absent on purpose: it
 #: loads a fitted rotation from the `fit` step's output, so it only resolves
@@ -79,11 +79,10 @@ def test_the_attention_scan_names_only_full_attention_layers():
     assert max(layers) == info.num_layers - 1
 
 
-def test_the_workflow_chain_loads():
-    from causalab.workflow.document import load_workflow
-
-    workflow = load_workflow(WORKFLOW, _env())
-    assert set(workflow.document.steps) == {
+#: workflow file stem -> its step names. The two halves of the protocol: step 2
+#: is a fan-out of independent probes, step 4 is a chain.
+WORKFLOW_STEPS = {
+    "qwen3_6_a3b_weekdays": {
         "locate",
         "best",
         "fit",
@@ -91,4 +90,23 @@ def test_the_workflow_chain_loads():
         "apply",
         "scan_heatmap",
         "iia_by_k",
-    }
+    },
+    "qwen3_6_a3b_exploration": {
+        "probe",
+        "logit_lens",
+        "knockout_attention",
+        "knockout_mlp",
+        "harvest",
+        "pca",
+        "spectrum",
+        "head_grid",
+    },
+}
+
+
+@pytest.mark.parametrize("stem", sorted(WORKFLOW_STEPS))
+def test_a_shipped_workflow_loads(stem: str):
+    from causalab.workflow.document import load_workflow
+
+    workflow = load_workflow(WORKFLOWS / f"{stem}.json", _env())
+    assert set(workflow.document.steps) == WORKFLOW_STEPS[stem]

--- a/tests/protocol/test_shipped_a3b_configs.py
+++ b/tests/protocol/test_shipped_a3b_configs.py
@@ -1,0 +1,94 @@
+"""The shipped qwen3.6-35b-a3b protocol set loads, expands, and asks the
+engine for exactly the capabilities its components imply.
+
+These are the runnable counterparts of the six exploratory/testing methods the
+Silico causalab documents describe, retargeted onto a hybrid MoE tower. They
+are pinned here on *shape* rather than on numbers: the numbers need the 67 GB
+checkpoint and belong in the golden tier, but "does the document still express
+the experiment" is a load-time question and this is where it is cheap.
+
+The point counts are the ones the campaign digests cover, so a change here is
+either an intended edit to a shipped config or an unintended change to sweep
+expansion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from causalab.protocol.loader import load
+from causalab.protocol.resolve import FileArtifacts, FileDatasets, ResolutionEnv
+
+pytestmark = pytest.mark.unit
+
+CONFIGS = Path(__file__).resolve().parents[2] / "causalab" / "configs"
+PROTOCOLS = CONFIGS / "protocols" / "qwen3_6_a3b"
+WORKFLOW = CONFIGS / "workflows" / "qwen3_6_a3b_weekdays.json"
+
+#: file stem -> expanded point count. `das_apply` is absent on purpose: it
+#: loads a fitted rotation from the `fit` step's output, so it only resolves
+#: inside the workflow that produces one.
+POINTS = {
+    "probe": 1,
+    "interchange": 1,
+    "control_positive": 1,
+    "control_negative": 1,
+    "locate_scan": 40,  # 20 layers x 2 positions
+    "logit_lens": 77,  # 11 source layers x 7 prompt positions
+    "knockout_head": 160,  # the TEN full-attention layers x 16 heads
+    "knockout_mlp": 40,  # every layer of the tower
+    "knockout_mlp_band3": 1,
+    "head_attribution": 1,
+    "harvest": 1,
+    "das_sweep": 6,  # 3 ranks x 2 seeds
+}
+
+
+def _env() -> ResolutionEnv:
+    return ResolutionEnv(
+        datasets=FileDatasets(root=CONFIGS / "data"),
+        artifacts=FileArtifacts(root=CONFIGS),
+    )
+
+
+def test_every_shipped_document_is_covered_here():
+    """A new file in the directory must land in POINTS, or it ships untested."""
+    on_disk = {p.stem for p in PROTOCOLS.glob("*.json")}
+    assert on_disk == set(POINTS) | {"das_apply"}
+
+
+@pytest.mark.parametrize("stem", sorted(POINTS))
+def test_a_shipped_document_loads_and_expands(stem: str):
+    loaded = load(PROTOCOLS / f"{stem}.json", _env())
+    assert len(loaded.expansion.points) == POINTS[stem]
+
+
+def test_the_attention_scan_names_only_full_attention_layers():
+    """The tower is 3:1 linear:full, so a head scan that swept the whole depth
+    would refuse at 30 of 40 layers — architecturally, not as a gap. The
+    document names the ten it can, and this is the check that keeps it in step
+    with the registry entry's `num_layers`."""
+    from causalab.protocol.registry import get_model_info
+
+    loaded = load(PROTOCOLS / "knockout_head.json", _env())
+    info = get_model_info("Qwen/Qwen3.6-35B-A3B")
+    layers = {doc.sites["attn"].layer for doc in loaded.point_documents}
+    assert layers == {3, 7, 11, 15, 19, 23, 27, 31, 35, 39}
+    assert max(layers) == info.num_layers - 1
+
+
+def test_the_workflow_chain_loads():
+    from causalab.workflow.document import load_workflow
+
+    workflow = load_workflow(WORKFLOW, _env())
+    assert set(workflow.document.steps) == {
+        "locate",
+        "best",
+        "fit",
+        "best_fit",
+        "apply",
+        "scan_heatmap",
+        "iia_by_k",
+    }


### PR DESCRIPTION
Stacked on #20.

The Silico causalab documents (goodfire-ai/silico#6393) describe six exploratory and testing methods and mark each one **Execution: stub** — the Hydra runner that used to invoke them was retired by the protocol refactor and nothing replaced the invocations. This adds them back as protocol documents, pointed at [`Qwen/Qwen3.6-35B-A3B`](https://huggingface.co/Qwen/Qwen3.6-35B-A3B) so they are exercised against a hybrid MoE tower rather than a dense Llama.

## What lands

Thirteen documents under `causalab/configs/protocols/qwen3_6_a3b/`, two workflows, the `weekdays` tables they run on, a registry entry for the model, and a shape test.

| document | method | points |
|---|---|---|
| `probe` | step 2 · probe | 1 |
| `logit_lens` | step 2 · logit lens (layer × position) | 77 |
| `locate_scan` | step 2 · paired examples / step 4 · locate | 40 |
| `knockout_head` | step 2 · knockout, attention head grid | 160 |
| `knockout_mlp` · `knockout_mlp_band3` | step 2 · knockout, MLP bands | 40 · 1 |
| `harvest` | step 2 · PCA's input + the mean-ablation reference | 1 |
| `head_attribution` | round 2's derived `attention_result` | 1 |
| `interchange` · `control_positive` · `control_negative` | step 4 · the test and its two controls | 1 each |
| `das_sweep` · `das_apply` | step 4 · DAS over k × seed, then the winner held out | 6 · 1 |

`qwen3_6_a3b_exploration.json` fans step 2 out; `qwen3_6_a3b_weekdays.json` chains step 4 (locate → select → fit → select → apply → plot).

PCA needed no new code — `causalab.analysis.fit_pca` already ships and is already named in the workflow spec's script table; what was missing was a document wiring a harvested read into it.

## The registry entry is load-bearing

The pure verbs are deliberately registry-only so digests never depend on the network (`cli.py:194`), which means `validate` and `explain` — the two verbs the Silico hypothesis-testing document tells an agent to reach for *first* — refuse outright on a model that is not registered. Shipping configs that name a model without registering it would have made that advice fail on the target model.

## Three things the documents encode rather than assume

Each was found by running them, not by reading:

- **A prompt-frame metric reduces exactly one position per example.** So the logit lens's (layer × position) grid is two swept axes, not one `pos: "all"` read that `top_k` then refuses.
- **`{"variable": "x"}` is looked up per role.** A bare `subject` column resolves against the counterfactual text too and refuses there; the tables carry `input_variables` / `counterfactual_inputs_variables` instead.
- **All seven weekday answers are ambiguous under this tokenizer** — both the bare and space-prefixed forms are single tokens. `token_form: "auto"` warns and resolves by luck, so every metric naming a token string pins `space_prefixed`.

## What the tower's shape costs

`full_attention_interval` is 4, so of 40 layers only **ten** carry a full-attention mixer. The head grid is 10 × 16, not 40 × 16; `mlp_activation` is not addressable at all (every layer is a sparse-MoE block, which has no `act_fn`); and KV-space components have two heads against sixteen query heads, so an out-of-range `head` is refused rather than silently yielding an empty slice.

## Verification

`2249 passed` (`-m "not golden"`), lint clean. Every document was smoke-run against `tiny-random/qwen3.5-moe` — the same architecture class, `Qwen3_5MoeForConditionalGeneration` with the same 3:1 linear:full layer types — and both workflows complete there. `sum_h attention_result == attention_output` holds to 1.0e-7.

The run on the checkpoint itself is in flight; results follow in a comment.

## Follow-up

These are written to become the golden tier: deterministic, small, complete `save` manifests. What they are pinned on here is *shape* — point counts and which layers may carry an attention component — because the numbers need the 67 GB checkpoint.