### PR TITLE
N8: the generated frame through one generate trace, step-anchored

### DIFF
--- a/causalab/neural/engines/nnsight_tracing/addresses.py
+++ b/causalab/neural/engines/nnsight_tracing/addresses.py
@@ -54,6 +54,7 @@ from typing import Callable, Iterable, Mapping
 
 __all__ = [
     "ADDRESSES",
+    "GENERATED_ADDRESSES",
     "FULL_ATTENTION",
     "LINEAR_ATTENTION",
     "MOE_EXPERTS",
@@ -361,4 +362,26 @@ MOE_EXPERTS: dict[str, SourceAddress] = {
 ADDRESSES: Mapping[str, Mapping[str, SourceAddress]] = {
     "full_attention": FULL_ATTENTION,
     "linear_attention": LINEAR_ATTENTION,
+}
+
+#: Interior addresses in the **generated frame** (N8), where decode dispatches
+#: different code than prefill. 📐 The one entry so far is the reason the table
+#: exists: at ``seq_len == 1`` under a cache the DeltaNet mixer runs the
+#: *recurrent* kernel (``modeling_qwen3_5_moe.py:507``) — a different function
+#: from the chunked one the prompt-frame address drills — and its state
+#: assignment fires once per decode step (``last_recurrent_state_2``; ``_0``
+#: is the zeros fallback, ``_1`` the untaken no-cache branch). An interior
+#: component absent here does not exist in the decode path (the chunk kernel,
+#: the conv's prefill branch, the grouped experts' sort are prefill facts) or
+#: has not been verified there — refused by name either way.
+GENERATED_ADDRESSES: Mapping[str, Mapping[str, SourceAddress]] = {
+    "linear_attention": {
+        "deltanet_state": SourceAddress(
+            module="linear_attn",
+            op_pattern="recurrent_gated_delta_rule",
+            peel=("implementation_0",),
+            field="last_recurrent_state_2",
+            fires="per_step",
+        ),
+    },
 }

--- a/causalab/neural/engines/nnsight_tracing/engine.py
+++ b/causalab/neural/engines/nnsight_tracing/engine.py
@@ -6,13 +6,12 @@ orchestration. What it does **not** declare says as much as what it does:
 
 * ``grad`` — training through traces is real design work (plan §2.5, D6);
   ``train`` documents route to the reference engine.
-* ``generate`` — step-anchored trace reads are phase N8.
 * ``quantized_weights`` — unverified through nnsight's loader; refused until
   someone needs it and proves it.
 
-Components it will serve that no other engine can — the DeltaNet state, the
-expert interiors (plan §3, N6–N7) — enter ``schema.py`` when their phases
-land, and routing carries documents here by name.
+The components only this engine serves — the fused-forward interiors of
+N6/N7, and the decode-side DeltaNet state (N8) — route here by name: the
+reference engine simply does not declare them.
 """
 
 from __future__ import annotations
@@ -44,6 +43,10 @@ class NnsightEngine(Engine):
             # the value multiply consumes it — a write to the mixer's returned
             # attn_weights would reach nothing (#53's finding)
             "writable_attention_probs",
+            # continuation reads through one model.generate trace, decode
+            # steps walked with tracer.iter (N8); writes stay in the prefill,
+            # as everywhere
+            "generate",
         }
     )
     # The whole current vocabulary, like the reference engine (N5): the

--- a/causalab/neural/engines/nnsight_tracing/executor.py
+++ b/causalab/neural/engines/nnsight_tracing/executor.py
@@ -29,9 +29,14 @@ require one switches it on around its trace and restores the model default
 after (D5). The applied set is stamped as execution metadata, never canonical
 form: the document and its digest are implementation-blind.
 
-v1 boundary: no generated frame (arrives with N8's ``tracer.iter`` step
-anchoring; routing keeps ``generate`` documents on the reference engine). It
-still refuses legibly here in case a document arrives unrouted.
+The generated frame (N8) runs the group as one ``model.generate`` trace:
+prompt-frame operations bind occurrence 0 of their locations — the prefill,
+which is the whole of "writes are prefill-only" — and the decode steps are
+walked with ``tracer.iter``, occurrence ``j`` of a per-forward location being
+the step that consumes generated token ``j-1``. Interior components need a
+generated-frame address of their own: decode dispatches different kernels
+than prefill (the recurrent delta rule replaces the chunked one), so the
+prompt-frame table is not evidence a tensor exists per step.
 """
 
 from __future__ import annotations
@@ -44,13 +49,22 @@ import torch
 
 from causalab.neural.engines.nnsight_tracing.addresses import (
     ADDRESSES,
+    GENERATED_ADDRESSES,
     MOE_EXPERTS,
     AddressResolutionError,
     SourceAddress,
     match_op,
 )
-from causalab.neural.shared.encoding import EncodedBatch
-from causalab.neural.shared.executor_base import ExecutorBase, tap_key
+from causalab.neural.shared.encoding import (
+    EncodedBatch,
+    continuation_frame,
+    resolve_steps,
+)
+from causalab.neural.shared.executor_base import (
+    ExecutorBase,
+    refuse_unstackable,
+    tap_key,
+)
 from causalab.neural.shared.layout import (
     from_contract,
     rebuild_payload,
@@ -61,7 +75,7 @@ from causalab.neural.shared.mechanisms import operand_names
 from causalab.neural.shared.sites import ResolvedSite, resolve_site
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.plan import generated_budget
-from causalab.protocol.schema import WriteSpec
+from causalab.protocol.schema import SiteSpec, WriteSpec
 
 __all__ = ["TracePointExecutor"]
 
@@ -102,19 +116,17 @@ class TracePointExecutor(ExecutorBase):
 
         batch = self._batch(input_role)
         taps = []
+        gen_taps: list[tuple[str, Any]] = []
+        depth = 0
         for rname, read in self.doc.reads.items():
             if str(read.model) != model or str(read.input) != input_role:
                 continue
-            if generated_budget(self.doc, read.pos) is not None:
-                raise ProtocolError(
-                    "P4",
-                    f"read {rname!r} addresses the generated frame, which the "
-                    "nnsight engine does not serve yet (its 'generate' "
-                    "capability is absent — the step-anchored trace reads are "
-                    "phase N8 of the engine plan). Routing sends such "
-                    "documents to the reference engine.",
-                )
-            taps.append((rname, read))
+            budget = generated_budget(self.doc, read.pos)
+            if budget is None:
+                taps.append((rname, read))
+            else:
+                gen_taps.append((rname, read))
+                depth = max(depth, budget)
 
         read_taps = {
             rname: self._wrap(resolve_site(self.bundle, self.doc.sites[str(read.site)]))
@@ -126,8 +138,28 @@ class TracePointExecutor(ExecutorBase):
                 write_names
             ).items()
         }
+        # A continuation read at lm_head is served from kept ln_final
+        # activations and projected at its addressed steps — the reference
+        # engine's own trick, shared here so both serve the same value.
+        gen_sites = {
+            rname: resolve_site(self.bundle, self.doc.sites[str(read.site)])
+            for rname, read in gen_taps
+        }
+        gen_wrapped: dict[str, ResolvedTap] = {}
+        for rname, site in gen_sites.items():
+            refuse_unstackable(rname, site)
+            capture_site = (
+                resolve_site(self.bundle, SiteSpec(component="ln_final"))
+                if site.component == "lm_head"
+                else site
+            )
+            gen_wrapped[rname] = self._wrap_generated(capture_site)
 
-        group_taps = [*read_taps.values(), *(tap for tap, _ in write_taps.values())]
+        group_taps = [
+            *read_taps.values(),
+            *(tap for tap, _ in write_taps.values()),
+            *gen_wrapped.values(),
+        ]
         required = frozenset(
             requirement
             for tap in group_taps
@@ -165,37 +197,100 @@ class TracePointExecutor(ExecutorBase):
         # reached), so a fire-index miss detected at build time is carried out
         # by hand and raised after.
         fire_miss: list[tuple[ResolvedTap, OutOfOrderError]] = []
+        gen_sinks: dict = {}
+        gen_result: Any = None
+        inputs = {
+            "input_ids": batch.input_ids,
+            "attention_mask": batch.attention_mask,
+        }
+
+        def trace_body(tracer: Any) -> Any:
+            # prompt-frame operations first: everything here binds occurrence
+            # 0 of its location — the prefill — which is the whole of "writes
+            # are prefill-only"
+            for _, _, op_kind, tap, entries in operations:
+                per_fire = tap.source is not None and tap.source.fires != "once"
+                try:
+                    if op_kind == "write" and per_fire:
+                        self._land_per_fire_writes(
+                            tracer, tap, entries, input_role, batch
+                        )
+                    elif op_kind == "write":
+                        self._land_writes(tap, entries, input_role, batch)
+                    elif per_fire:
+                        saves[tap_key(tap.site, tap.source)] = self._collect_per_fire(
+                            tracer, tap
+                        )
+                    else:
+                        saves[tap_key(tap.site, tap.source)] = nnsight.save(
+                            self._tap_contract(tap, batch_size)
+                        )
+                except OutOfOrderError as error:
+                    if not per_fire:
+                        raise
+                    fire_miss.append((tap, error))
+                    break
+            if not depth:
+                return None
+            # decode steps: occurrence j of a per-forward location is the
+            # step consuming generated token j-1, so fires 1..depth are
+            # generated positions 0..depth-1
+            gen_order = sorted(
+                {
+                    tap_key(tap.site, tap.source): tap for tap in gen_wrapped.values()
+                }.items(),
+                key=lambda item: item[1].site.depth,
+            )
+            for key, _tap in gen_order:
+                gen_sinks[key] = nnsight.save([])
+            # 📐 rule 3 of the fire-counting probes: occurrences are counted
+            # per location, and a decode-only op (the recurrent delta kernel)
+            # has no prefill occurrence — so its occurrence j is step j+1, one
+            # off. Anchoring each body on a location that fires every forward
+            # makes the iteration index mean the forward; the ops after it
+            # follow the model in order. Skipped when the first tap already is
+            # such a location (every module boundary and interface slot is).
+            needs_anchor = gen_order and (
+                gen_order[0][1].source is not None
+                and gen_order[0][1].source.fires != "once"
+            )
+            embedding = (
+                self.bundle.model.transformer.wte
+                if self.bundle.is_gpt2_family
+                else self.bundle.model.model.embed_tokens
+            )
+            for _step in tracer.iter[1 : depth + 1]:
+                if needs_anchor:
+                    _ = embedding.input
+                for key, tap in gen_order:
+                    gen_sinks[key].append(self._generated_step_value(tap, batch_size))
+            # ⚠️ last: `tracer.result` consumes the whole run, so a request
+            # after it is never reached (measured)
+            return nnsight.save(tracer.result)
+
         with torch.no_grad():
             with self._switched_implementations(required):
-                with self.bundle.model.trace(
-                    {
-                        "input_ids": batch.input_ids,
-                        "attention_mask": batch.attention_mask,
-                    },
-                    position_ids=batch.position_ids(),
-                ) as tracer:
-                    for _, _, op_kind, tap, entries in operations:
-                        per_fire = tap.source is not None and tap.source.fires != "once"
-                        try:
-                            if op_kind == "write" and per_fire:
-                                self._land_per_fire_writes(
-                                    tracer, tap, entries, input_role, batch
-                                )
-                            elif op_kind == "write":
-                                self._land_writes(tap, entries, input_role, batch)
-                            elif per_fire:
-                                saves[tap_key(tap.site, tap.source)] = (
-                                    self._collect_per_fire(tracer, tap)
-                                )
-                            else:
-                                saves[tap_key(tap.site, tap.source)] = nnsight.save(
-                                    self._tap_contract(tap, batch_size)
-                                )
-                        except OutOfOrderError as error:
-                            if not per_fire:
-                                raise
-                            fire_miss.append((tap, error))
-                            break
+                if depth:
+                    # depth+1 forwards give every generated position its
+                    # activations, the last token's included (the extra draw
+                    # is never consumed — the reference engine's own decode
+                    # loop, §2.3); eos_token_id=None keeps decoding past an
+                    # eos exactly as that loop does, and widths truncate
+                    # reads post-hoc. `generate` must be called in the with
+                    # expression itself: it is @traceable, and a plain call
+                    # just generates.
+                    with self.bundle.model.generate(
+                        inputs,
+                        max_new_tokens=depth + 1,
+                        do_sample=False,
+                        eos_token_id=None,
+                    ) as tracer:
+                        gen_result = trace_body(tracer)
+                else:
+                    with self.bundle.model.trace(
+                        inputs, position_ids=batch.position_ids()
+                    ) as tracer:
+                        trace_body(tracer)
         self._trace_sources = {}
         if fire_miss:
             tap, error = fire_miss[0]
@@ -227,6 +322,18 @@ class TracePointExecutor(ExecutorBase):
                 self._read_values[rname] = self._finalize_read(
                     rname, read, tap.site, raw, batch, input_role
                 )
+        if depth:
+            self._finalize_generated(
+                model,
+                input_role,
+                batch=batch,
+                depth=depth,
+                gen_taps=gen_taps,
+                gen_sites=gen_sites,
+                gen_wrapped=gen_wrapped,
+                gen_sinks=gen_sinks,
+                gen_result=gen_result,
+            )
         self._groups_run.add((model, input_role))
 
     # ------------------------------------------------------------------ #
@@ -288,31 +395,47 @@ class TracePointExecutor(ExecutorBase):
             address.arg,
         )
         if key not in self._trace_sources:
-            root = self._drill(site.module.source, address.op_pattern, site)
-            perm = None
-            if address.align is not None:
-                # its own cache slot: several addresses share one sort op, and
-                # the permutation must be requested exactly once per trace
-                perm_key = (id(site.module), address.op_pattern, "align", address.align)
-                if perm_key not in self._trace_sources:
-                    self._trace_sources[perm_key] = self._drill(
-                        root.source, address.align, site
-                    ).output[1]
-                perm = self._trace_sources[perm_key]
-            op = root
-            for entry in address.peel:
-                op = self._drill(op.source, entry, site)
-            if address.field is not None:
-                op = self._drill(op.source, address.field, site)
-            if address.arg is not None:
-                index, keyword = address.arg
-                self._trace_sources[key] = (op.inputs[index][keyword], perm)
-            else:
-                self._trace_sources[key] = (op.output, perm)
+            self._trace_sources[key] = self._navigate_value(
+                tap, perm_cache=self._trace_sources
+            )
         value, perm = self._trace_sources[key]
         if address.tuple_index is not None:
             value = value[address.tuple_index]
         return value, perm
+
+    def _navigate_value(
+        self, tap: ResolvedTap, perm_cache: dict | None = None
+    ) -> tuple[Any, Any]:
+        """The uncached navigation: (pre-``tuple_index`` value, permutation).
+
+        The step loop of the generated frame calls this directly — there each
+        request must bind the *current* occurrence, so a cached proxy would
+        hand back an earlier step's tensor.
+        """
+        address = tap.source
+        assert address is not None
+        site = tap.site
+        root = self._drill(site.module.source, address.op_pattern, site)
+        perm = None
+        if address.align is not None:
+            # its own cache slot: several addresses share one sort op, and
+            # the permutation must be requested exactly once per trace
+            perm_key = (id(site.module), address.op_pattern, "align", address.align)
+            if perm_cache is not None and perm_key in perm_cache:
+                perm = perm_cache[perm_key]
+            else:
+                perm = self._drill(root.source, address.align, site).output[1]
+                if perm_cache is not None:
+                    perm_cache[perm_key] = perm
+        op = root
+        for entry in address.peel:
+            op = self._drill(op.source, entry, site)
+        if address.field is not None:
+            op = self._drill(op.source, address.field, site)
+        if address.arg is not None:
+            index, keyword = address.arg
+            return op.inputs[index][keyword], perm
+        return op.output, perm
 
     def _present_native(self, tap: ResolvedTap, value: Any, perm: Any) -> Any:
         """The value as the declared shape describes it — semantic order.
@@ -535,6 +658,135 @@ class TracePointExecutor(ExecutorBase):
                 f"{n_fires} times on this batch",
             )
         return [[index % n_fires]] * n_rows
+
+    # ------------------------------------------------------------------ #
+    # the generated frame (N8): step-anchored reads under model.generate
+    # ------------------------------------------------------------------ #
+
+    def _wrap_generated(self, site: ResolvedSite) -> ResolvedTap:
+        """A continuation tap's landing.
+
+        Module boundaries and the stackable interface slots are the prompt
+        frame's own landings, one occurrence per decode step. An *interior*
+        component must appear in the generated-frame table — decode dispatches
+        different code than prefill (the recurrent delta kernel replaces the
+        chunked one), so a prompt-frame address is not evidence the tensor
+        exists per step.
+        """
+        if site.kind == "interior":
+            stream = self.bundle.stream_at(site.layer)
+            address = GENERATED_ADDRESSES.get(stream, {}).get(site.component)
+            if address is None:
+                raise ProtocolError(
+                    "P4",
+                    f"component {site.component!r} has no generated-frame "
+                    "address in the nnsight engine's tables "
+                    "(neural/engines/nnsight_tracing/addresses.py): the decode "
+                    "path dispatches different kernels than prefill, so an "
+                    "interior tensor is only served per step once its decode "
+                    "address is verified. Read it in the prompt frame.",
+                )
+            return ResolvedTap(site=site, source=address)
+        if site.interface_slot is not None:
+            return self._wrap(site)
+        return ResolvedTap(site=site)
+
+    def _generated_step_value(self, tap: ResolvedTap, batch_size: int) -> Any:
+        """One decode step's contract tensor for one continuation tap.
+
+        Navigated fresh inside the step body — ``tracer.iter`` binds each
+        request to the current occurrence, so the per-trace cache must not
+        hand back an earlier step's value.
+        """
+        site = tap.site
+        if tap.source is None:
+            envoy = site.module
+            if site.kind == "out":
+                native = tap_tensor(envoy.output, site.tuple_index)
+            else:
+                native = envoy.input
+            return to_contract(native, site.shape, batch_size=batch_size)
+        value, perm = self._navigate_value(tap)
+        if tap.source.tuple_index is not None:
+            value = value[tap.source.tuple_index]
+        native = self._present_native(tap, value, perm)
+        if tap.source.fires != "once":
+            # a per-step state has no position axis of its own: give it the
+            # declared shape's one-step form, (b, 1, heads, feature)
+            heads = site.shape.head_space
+            width = site.shape.width
+            assert heads is not None and width is not None
+            native = native.reshape(-1, 1, heads, width // heads)
+        return to_contract(native, site.shape, batch_size=batch_size)
+
+    def _finalize_generated(
+        self,
+        model: str,
+        input_role: str,
+        *,
+        batch: EncodedBatch,
+        depth: int,
+        gen_taps: list[tuple[str, Any]],
+        gen_sites: dict[str, ResolvedSite],
+        gen_wrapped: dict[str, ResolvedTap],
+        gen_sinks: dict,
+        gen_result: Any,
+    ) -> None:
+        """Build the continuation frame and finalize its reads — the same
+        step-space semantics as the reference engine's decode."""
+        prompt_len = int(batch.input_ids.shape[1])
+        generated = gen_result[:, prompt_len:][:, :depth].detach().cpu()
+        rows_n = int(generated.shape[0])
+        eos = self.bundle.tokenizer.eos_token_id
+        widths: list[int] = []
+        for row in range(rows_n):
+            width = depth
+            if eos is not None:
+                hit = (generated[row] == eos).nonzero()
+                if hit.numel():
+                    width = int(hit[0].item())
+            widths.append(width)
+        continuation = continuation_frame(
+            self.bundle.tokenizer, generated, tuple(widths)
+        )
+        self._continuations[(model, input_role)] = continuation
+
+        dataset_rows = self.role_rows[input_role]
+        field = self.role_fields[input_role]
+        head = None
+        for rname, read in gen_taps:
+            site = gen_sites[rname]
+            tap = gen_wrapped[rname]
+            sink = gen_sinks[tap_key(tap.site, tap.source)]
+            frame = torch.cat(list(sink), dim=1)  # (b, steps, feature)
+            per_row = [
+                resolve_steps(
+                    self._spec(read.pos),
+                    continuation,
+                    row,
+                    dataset_row=dataset_rows[row],
+                    field=field,
+                )
+                for row in range(rows_n)
+            ]
+            self._read_steps[rname] = per_row
+            project = None
+            if tap.site.component != site.component:  # ln_final kept, lm_head owed
+                head = (
+                    head
+                    or resolve_site(self.bundle, SiteSpec(component="lm_head")).module
+                )
+                project = head
+            self._read_values[rname] = self._finalize_read(
+                rname,
+                read,
+                site,
+                frame,
+                batch,
+                input_role,
+                per_row=per_row,
+                project=project,
+            )
 
     @contextlib.contextmanager
     def _switched_implementations(self, required: frozenset[str]) -> Iterator[None]:

--- a/causalab/neural/engines/pytorch_hooks/executor.py
+++ b/causalab/neural/engines/pytorch_hooks/executor.py
@@ -34,12 +34,17 @@ from causalab.neural.engines.pytorch_hooks.attention_interface import (
     InterfaceTap,
     attention_interface_taps,
 )
-from causalab.neural.shared.encoding import Continuation, EncodedBatch, resolve_steps
+from causalab.neural.shared.encoding import (
+    EncodedBatch,
+    continuation_frame,
+    resolve_steps,
+)
 from causalab.neural.shared.executor_base import (
     ExecutorBase,
     RaggedValue,
     TapKey,
     document_seed,
+    refuse_unstackable,
     tap_key,
 )
 from causalab.protocol.shapes import FeatureShape
@@ -255,7 +260,7 @@ class PointExecutor(ExecutorBase):
             interface: dict[int, list[InterfaceTap]] = {}
             batch_size = batch.input_ids.shape[0]
             for name, site in gen_capture_sites.items():
-                _refuse_unstackable(name, site)
+                refuse_unstackable(name, site)
                 key = tap_key(site)
                 if key in steps:
                     continue
@@ -310,7 +315,7 @@ class PointExecutor(ExecutorBase):
                 if hit.numel():
                     width = int(hit[0].item())
             widths.append(width)
-        continuation = _continuation_frame(
+        continuation = continuation_frame(
             self.bundle.tokenizer, generated, tuple(widths)
         )
         self._continuations[(model, input_role)] = continuation
@@ -451,48 +456,6 @@ def _refuse_interior(what: str, site: ResolvedSite) -> None:
     )
 
 
-def _refuse_unstackable(name: str, site: ResolvedSite) -> None:
-    """Refuse a continuation read whose steps do not stack into a frame.
-
-    📐 A decode step attends over the whole KV cache, so a tensor indexed by the
-    positions being attended *to* is ``prompt + step`` long at step ``step``
-    while the query axis stays 1. The accumulating sink concatenates steps on
-    dim 1, which for an ordinary tap is the position axis, so such a tap either
-    raises a bare torch size error (measured: "Expected size 9 but got size 10")
-    or, for a single-step budget, silently returns one step shaped like a frame.
-    Neither is a continuation read.
-
-    Both conditions are read off the declared axes rather than a component list:
-
-    * **two position axes** — the attention pattern and the scores. There is no
-      non-arbitrary answer to which of them the steps stack along;
-    * **one position axis, over the keys** — ``attention_key``. Its own length
-      is what grows, so consecutive steps are different lengths.
-
-    ``attention_query`` and ``attention_z`` are query-axis-shaped and accumulate
-    correctly, which is why this is a property of the axes and not of "anything
-    inside the attention function".
-    """
-    shape = site.shape
-    if shape.has_contract_form and not any(
-        axis.kind == "position" and axis.name == "key" for axis in shape.axes
-    ):
-        return
-    why = (
-        "it has two position axes, so there is no single axis the decode steps "
-        "stack along"
-        if not shape.has_contract_form
-        else "its position axis runs over the positions being attended to, "
-        "which under a KV cache is the whole prefix and grows by one per step"
-    )
-    raise ProtocolError(
-        "P4",
-        f"read {name!r} reads {site.component!r} in the generated frame, whose "
-        f"shape is {shape.describe()}: {why}, so the steps do not stack into "
-        "one tensor. Read it in the prompt frame.",
-    )
-
-
 @contextlib.contextmanager
 def _installed(
     module: Any,
@@ -608,34 +571,3 @@ def _accumulating(
         yield
     finally:
         handle.remove()
-
-
-def _continuation_frame(
-    tokenizer: Any, generated: torch.Tensor, widths: tuple[int, ...]
-) -> Continuation:
-    """Build the frame the decode produced, characters included.
-
-    Token spans come from incremental detokenization — decode the row's
-    first ``k`` tokens, then ``k + 1``, and the growth is token ``k``'s
-    span. Re-encoding the finished text would not do: a tokenizer is free
-    to merge across a boundary the decode never saw, and the spans have to
-    describe the tokens the model actually emitted.
-    """
-    texts: list[str] = []
-    offsets: list[tuple[tuple[int, int], ...]] = []
-    for row, width in enumerate(widths):
-        ids = [int(t) for t in generated[row, :width]]
-        spans: list[tuple[int, int]] = []
-        text = ""
-        for k in range(width):
-            grown = tokenizer.decode(ids[: k + 1], skip_special_tokens=True)
-            spans.append((len(text), len(grown)))
-            text = grown
-        texts.append(text)
-        offsets.append(tuple(spans))
-    return Continuation(
-        token_ids=generated.detach().cpu(),
-        widths=widths,
-        texts=tuple(texts),
-        offsets=tuple(offsets),
-    )

--- a/causalab/neural/shared/encoding.py
+++ b/causalab/neural/shared/encoding.py
@@ -76,6 +76,7 @@ from causalab.protocol.schema import PositionSpec, concrete_int, concrete_str
 __all__ = [
     "Continuation",
     "EncodedBatch",
+    "continuation_frame",
     "encode",
     "resolve_position",
     "resolve_steps",
@@ -442,3 +443,34 @@ def resolve_position(
     if a < 0 or b <= a:
         raise ProtocolError("P2", f"span [{a}, {b}) is not a forward window")
     return check(list(range(start + a, start + b)))
+
+
+def continuation_frame(
+    tokenizer: Any, generated: torch.Tensor, widths: tuple[int, ...]
+) -> Continuation:
+    """Build the frame the decode produced, characters included.
+
+    Token spans come from incremental detokenization — decode the row's
+    first ``k`` tokens, then ``k + 1``, and the growth is token ``k``'s
+    span. Re-encoding the finished text would not do: a tokenizer is free
+    to merge across a boundary the decode never saw, and the spans have to
+    describe the tokens the model actually emitted.
+    """
+    texts: list[str] = []
+    offsets: list[tuple[tuple[int, int], ...]] = []
+    for row, width in enumerate(widths):
+        ids = [int(t) for t in generated[row, :width]]
+        spans: list[tuple[int, int]] = []
+        text = ""
+        for k in range(width):
+            grown = tokenizer.decode(ids[: k + 1], skip_special_tokens=True)
+            spans.append((len(text), len(grown)))
+            text = grown
+        texts.append(text)
+        offsets.append(tuple(spans))
+    return Continuation(
+        token_ids=generated.detach().cpu(),
+        widths=widths,
+        texts=tuple(texts),
+        offsets=tuple(offsets),
+    )

--- a/causalab/neural/shared/executor_base.py
+++ b/causalab/neural/shared/executor_base.py
@@ -51,7 +51,14 @@ from causalab.protocol.schema import (
     WriteSpec,
 )
 
-__all__ = ["ExecutorBase", "RaggedValue", "TapKey", "document_seed", "tap_key"]
+__all__ = [
+    "ExecutorBase",
+    "RaggedValue",
+    "TapKey",
+    "document_seed",
+    "refuse_unstackable",
+    "tap_key",
+]
 
 
 def document_seed(doc: Document) -> int:
@@ -779,3 +786,45 @@ class ExecutorBase:
             else:
                 f.index_copy_(-1, dims, apply_renormalize(select(f), select(f0)))
         return stack.inverse(f, errs)
+
+
+def refuse_unstackable(name: str, site: ResolvedSite) -> None:
+    """Refuse a continuation read whose steps do not stack into a frame.
+
+    📐 A decode step attends over the whole KV cache, so a tensor indexed by the
+    positions being attended *to* is ``prompt + step`` long at step ``step``
+    while the query axis stays 1. The accumulating sink concatenates steps on
+    dim 1, which for an ordinary tap is the position axis, so such a tap either
+    raises a bare torch size error (measured: "Expected size 9 but got size 10")
+    or, for a single-step budget, silently returns one step shaped like a frame.
+    Neither is a continuation read.
+
+    Both conditions are read off the declared axes rather than a component list:
+
+    * **two position axes** — the attention pattern and the scores. There is no
+      non-arbitrary answer to which of them the steps stack along;
+    * **one position axis, over the keys** — ``attention_key``. Its own length
+      is what grows, so consecutive steps are different lengths.
+
+    ``attention_query`` and ``attention_z`` are query-axis-shaped and accumulate
+    correctly, which is why this is a property of the axes and not of "anything
+    inside the attention function".
+    """
+    shape = site.shape
+    if shape.has_contract_form and not any(
+        axis.kind == "position" and axis.name == "key" for axis in shape.axes
+    ):
+        return
+    why = (
+        "it has two position axes, so there is no single axis the decode steps "
+        "stack along"
+        if not shape.has_contract_form
+        else "its position axis runs over the positions being attended to, "
+        "which under a KV cache is the whole prefix and grows by one per step"
+    )
+    raise ProtocolError(
+        "P4",
+        f"read {name!r} reads {site.component!r} in the generated frame, whose "
+        f"shape is {shape.describe()}: {why}, so the steps do not stack into "
+        "one tensor. Read it in the prompt frame.",
+    )

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -343,9 +343,14 @@ execution order:
   an integer chunk index; text anchors have nothing to resolve against there.
   Per-token prefill state does not exist: the recurrent kernel runs only in
   single-token decode, by the modeling code's own dispatch, so it is refused
-  by name rather than served at a granularity the kernel does not have. These
-  live inside one fused forward — the nnsight engine serves them through its
-  `.source` address table; the reference engine refuses them by name.
+  by name rather than served at a granularity the kernel does not have. In
+  the **generated frame** the state *is* per token: each decode step runs the
+  recurrent kernel once, and a continuation read of `deltanet_state` gets one
+  state per generated position — a separate, decode-verified address, because
+  decode dispatches different kernels than prefill (interior components
+  without one refuse by name in that frame). These live inside one fused
+  forward — the nnsight engine serves them through its `.source` address
+  table; the reference engine refuses them by name.
 - **`attention_result` is the per-head contribution to the residual stream**,
   and the only component the model never computes: the block projects the whole
   `attention_premix` at once, so what the forward pass forms is the *sum* over

--- a/tests/neural/engines/nnsight_tracing/test_generate_frame_nnsight.py
+++ b/tests/neural/engines/nnsight_tracing/test_generate_frame_nnsight.py
@@ -1,0 +1,255 @@
+"""The generated frame on the nnsight engine (engine plan §10, N8).
+
+One ``model.generate`` trace per group: prompt-frame taps and writes bind
+occurrence 0 of their locations — the prefill — and the decode steps are
+walked with ``tracer.iter``, occurrence ``j`` being the step that consumes
+generated token ``j-1``. The reference engine hand-rolls the same decode with
+hooks, which makes it the oracle here: the same documents through both, ids
+and activations agreeing.
+
+Plus what parity cannot say: the greedy self-consistency pin (the argmax of a
+continuation ``lm_head`` read reproduces the decoded ids — from the
+generation-frame handoff note), and the N7 bridge — the DeltaNet state read
+per decode step, through the *recurrent* kernel's own address, continuous
+with the prefill chunks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from causalab.neural.engines.nnsight_tracing.engine import NnsightEngine
+from causalab.neural.engines.nnsight_tracing.executor import TracePointExecutor
+from causalab.neural.engines.pytorch_hooks.executor import PointExecutor
+from causalab.protocol.errors import ProtocolError
+from causalab.protocol.schema import parse_document
+from causalab.protocol.validate import validate_document
+
+from tests.protocol._docs import in_order
+
+from .test_parity_module_boundaries import _assert_same, _data, _executor, _refusal
+
+pytestmark = pytest.mark.smoke
+
+DEPTH = 4
+QWEN_ATTENTION_LAYER = 3
+DELTANET_LAYER = 0
+
+
+def _gen_doc(component: str, *, layer: int | None, pos: dict | None = None) -> dict:
+    site: dict = {"component": component}
+    if layer is not None:
+        site["layer"] = layer
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": _data(with_cf=False),
+        "sites": {"tap": site},
+        "positions": {
+            "window": pos or {"generated": {"max_new_tokens": DEPTH}, "all": True}
+        },
+        "reads": {
+            "r": {"site": "tap", "pos": "window", "model": "original", "input": "base"}
+        },
+        "save": [
+            {
+                "value": "r",
+                "model": "original",
+                "input": "base",
+                "file_path": "a.safetensors",
+            }
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# parity: the reference engine's decode is the oracle
+# --------------------------------------------------------------------------- #
+
+LLAMA_GEN_READS = [
+    ("block_output", 1),
+    ("attention_output", 1),
+    ("mlp_output", 1),
+    ("attention_query", 1),
+    ("attention_z", 1),
+    ("ln_final", None),
+    ("lm_head", None),
+]
+
+
+@pytest.mark.parametrize("component,layer", LLAMA_GEN_READS)
+def test_generated_read_parity(hooks_llama, trace_llama, component, layer):
+    doc = _gen_doc(component, layer=layer)
+    hooked = _executor(PointExecutor, doc, hooks_llama, with_cf=False).read_value("r")
+    traced = _executor(TracePointExecutor, doc, trace_llama, with_cf=False).read_value(
+        "r"
+    )
+    _assert_same(hooked, traced, f"generated read of {component!r}")
+
+
+def test_generated_parity_on_the_hybrid_fixture(hooks_qwen, trace_qwen):
+    """The target architecture in miniature: a DeltaNet layer's boundary and a
+    full-attention interior slot, per step."""
+    for component, layer in (
+        ("attention_output", DELTANET_LAYER),
+        ("attention_z", QWEN_ATTENTION_LAYER),
+        ("lm_head", None),
+    ):
+        doc = _gen_doc(component, layer=layer)
+        hooked = _executor(PointExecutor, doc, hooks_qwen, with_cf=False).read_value(
+            "r"
+        )
+        traced = _executor(
+            TracePointExecutor, doc, trace_qwen, with_cf=False
+        ).read_value("r")
+        _assert_same(hooked, traced, f"generated read of {component!r}")
+
+
+def test_the_decoded_ids_agree_with_the_reference_engine(hooks_qwen, trace_qwen):
+    """Same greedy continuation on both engines — the frame itself, not just
+    the activations."""
+    doc = _gen_doc("block_output", layer=0)
+    hooked = _executor(PointExecutor, doc, hooks_qwen, with_cf=False)
+    traced = _executor(TracePointExecutor, doc, trace_qwen, with_cf=False)
+    hooked.read_value("r"), traced.read_value("r")
+    assert hooked.generated_ids("r") == traced.generated_ids("r")
+    assert hooked.addressed_steps("r") == traced.addressed_steps("r")
+
+
+def test_a_write_reaches_the_continuation_identically(hooks_qwen, trace_qwen):
+    """Writes are prefill-only on both engines (here: everything binds
+    occurrence 0 — the prefill), and reach the continuation through the first
+    token and the cache. The patched continuation read must agree."""
+    doc = _gen_doc("block_output", layer=0)
+    doc["data"] = _data(with_cf=True)
+    doc["sites"]["src"] = {"component": "block_output", "layer": 0}
+    doc["reads"]["v_cf"] = {
+        "site": "src",
+        "pos": -1,
+        "model": "original",
+        "input": "counterfactual",
+    }
+    doc["reads"]["r"]["model"] = "patched"
+    doc["writes"] = {"patch": {"site": "src", "pos": -1, "do": {"swap": "v_cf"}}}
+    doc["intervened_models"] = {"patched": {"input": "base", "writes": ["patch"]}}
+    doc["save"][0]["model"] = "patched"
+    hooked = _executor(PointExecutor, doc, hooks_qwen, with_cf=True)
+    traced = _executor(TracePointExecutor, doc, trace_qwen, with_cf=True)
+    _assert_same(
+        hooked.read_value("r"),
+        traced.read_value("r"),
+        "a patched continuation read",
+    )
+    assert hooked.generated_ids("r") == traced.generated_ids("r")
+
+
+# --------------------------------------------------------------------------- #
+# the greedy self-consistency pin
+# --------------------------------------------------------------------------- #
+
+
+def test_the_lm_head_argmax_reproduces_the_decoded_ids(trace_qwen):
+    """The distribution at generated position i is the one AFTER token i, so
+    its argmax is token i+1 — the frame and the values must tell one story."""
+    doc = _gen_doc("lm_head", layer=None)
+    executor = _executor(TracePointExecutor, doc, trace_qwen, with_cf=False)
+    value = executor.read_value("r")  # (b, steps, vocab)
+    ids = executor.generated_ids("r")
+    steps = executor.addressed_steps("r")
+    for row, row_steps in enumerate(steps):
+        for k, step in enumerate(row_steps[:-1]):
+            assert int(value[row, step].argmax()) == ids[row][k + 1]
+
+
+# --------------------------------------------------------------------------- #
+# the N7 bridge: the DeltaNet state per decode step
+# --------------------------------------------------------------------------- #
+
+
+def _single_row(trace_qwen, doc_raw: dict, text: str) -> TracePointExecutor:
+    doc = parse_document(in_order(doc_raw))
+    validate_document(doc, engine_is_local=True)
+    return TracePointExecutor(
+        doc,
+        trace_qwen,
+        role_rows={"base": [{"input": text}]},
+        role_fields={"base": "input"},
+        load_tensors=lambda path: (_ for _ in ()).throw(KeyError(path)),
+    )
+
+
+def test_the_deltanet_state_reads_per_decode_step(trace_qwen):
+    """Served through the *recurrent* kernel's address — the decode path's own
+    dispatch — with one state per generated position, continuous in shape
+    with the prefill chunks and advancing every step."""
+    info = trace_qwen.info
+    doc = _gen_doc("deltanet_state", layer=DELTANET_LAYER)
+    doc["sites"]["prefill"] = {"component": "deltanet_state", "layer": DELTANET_LAYER}
+    doc["reads"]["last_chunk"] = {
+        "site": "prefill",
+        "pos": -1,
+        "model": "original",
+        "input": "base",
+    }
+    doc["save"].append(
+        {
+            "value": "last_chunk",
+            "model": "original",
+            "input": "base",
+            "file_path": "c.safetensors",
+        }
+    )
+    executor = _single_row(trace_qwen, doc, "the quick brown fox jumps")
+    per_step = executor.read_value("r")
+    width = (
+        info.linear_num_value_heads
+        * info.linear_key_head_dim
+        * info.linear_value_head_dim
+    )
+    assert tuple(per_step.shape) == (1, DEPTH, width)
+    # the state advances every step...
+    for j in range(DEPTH - 1):
+        assert float((per_step[:, j + 1] - per_step[:, j]).abs().max()) > 0.0
+    # ...and continues from the prefill: the first decode state is one token's
+    # update away from the last chunk state, not a re-initialization
+    last_chunk = executor.read_value("last_chunk")
+    drift_from_prefill = float((per_step[:, 0] - last_chunk[:, 0]).abs().max())
+    fresh_scale = float(per_step[:, 0].abs().max())
+    assert 0.0 < drift_from_prefill < fresh_scale * 10
+
+
+def test_an_expert_interior_read_in_the_generated_frame_refuses_by_name(trace_qwen):
+    """No generated-frame address is verified for the grouped experts kernel,
+    and decode dispatches different code than prefill — refused by name, not
+    served from the wrong table."""
+    doc = _gen_doc("expert_gate_proj", layer=0)
+    with pytest.raises(ProtocolError, match="generated-frame address"):
+        _executor(TracePointExecutor, doc, trace_qwen, with_cf=False).run_all()
+
+
+# --------------------------------------------------------------------------- #
+# refusals stay shared: the axes rule, the same words on both engines
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "component", ["attention_key", "attention_scores", "attention_probs"]
+)
+def test_unstackable_generated_reads_refuse_identically(
+    hooks_qwen, trace_qwen, component
+):
+    """A key-indexed tensor grows with the cache, so its steps do not stack —
+    a fact about the declared axes, shared by both engines word for word."""
+    doc = _gen_doc(component, layer=QWEN_ATTENTION_LAYER)
+    assert _refusal(PointExecutor, doc, hooks_qwen) == _refusal(
+        TracePointExecutor, doc, trace_qwen
+    )
+
+
+def test_routing_no_longer_sends_generate_documents_away():
+    doc = parse_document(in_order(_gen_doc("block_output", layer=1)))
+    assert "generate" in NnsightEngine().capabilities
+    from causalab.protocol.engine import requires
+
+    assert "generate" in requires(doc)
+    assert requires(doc) <= NnsightEngine().effective_capabilities

--- a/tests/neural/engines/nnsight_tracing/test_parity_module_boundaries.py
+++ b/tests/neural/engines/nnsight_tracing/test_parity_module_boundaries.py
@@ -322,10 +322,17 @@ def test_attention_probs_no_longer_routes_away():
     assert "writable_attention_probs" in NnsightEngine().capabilities
 
 
-def test_a_generated_read_reaching_the_executor_refuses_by_phase(trace_llama):
+def test_a_generated_read_is_served_and_agrees_with_the_reference_engine(
+    hooks_llama, trace_llama
+):
+    """N8 flipped this pin from a phase refusal to the behavior itself: a
+    continuation read decodes through one generate trace here, and the value
+    matches the reference engine's hand-rolled greedy decode."""
     doc = _read_doc("block_output", 1)
     doc["positions"] = {"tail": {"generated": {"max_new_tokens": 4}, "index": -1}}
     doc["reads"]["r"]["pos"] = "tail"
-    with pytest.raises(ProtocolError) as excinfo:
-        _executor(TracePointExecutor, doc, trace_llama, with_cf=False).run_all()
-    assert "N8" in str(excinfo.value)
+    hooked = _executor(PointExecutor, doc, hooks_llama, with_cf=False).read_value("r")
+    traced = _executor(TracePointExecutor, doc, trace_llama, with_cf=False).read_value(
+        "r"
+    )
+    _assert_same(hooked, traced, "a generated block_output read")


### PR DESCRIPTION
Phase N8 (cockpit `notes/causalab-nnsight-engine-upstreaming-and-pr19.md` §10), stacked on #67 — its own PR per D11: `generate` is a routing-visible capability with its own digest gate.

## What this adds

- **The `generate` capability**: a group that decodes a continuation runs as **one `model.generate` trace**. Prompt-frame taps and writes bind occurrence 0 of their locations — the prefill, which is the whole of "writes are prefill-only" — and decode steps are walked with `tracer.iter`, occurrence `j` of a per-forward location being the step consuming generated token `j-1`. `depth+1` forwards give every generated position its activations, the last token's included; `eos_token_id=None` keeps decoding past an eos exactly as the reference engine's hand-rolled loop does, with widths truncating reads post-hoc.
- **Shared frame machinery**: `continuation_frame` and the axis-derived `refuse_unstackable` move to `neural/shared/`, so both engines run one implementation of the continuation frame and its refusals (refusal parity pinned word for word).
- **The N7 bridge**: `deltanet_state` in the generated frame is served per decode step through the **recurrent** kernel's own address (`last_recurrent_state_2`, same `implementation_0` peel) — a separate `GENERATED_ADDRESSES` table, because decode dispatches different kernels than prefill and a prompt-frame address is not evidence a tensor exists per step. Interiors without a decode-verified address refuse by name there.
- Three measured rules the code carries: `tracer.result` must be requested **last** (it consumes the run); `generate` is `@traceable`, so the call must sit in the `with` expression itself; a decode-only op's occurrences are one off from the forwards (fire-counting rule 3), so a step body whose first tap is one gets anchored on the embedding input.

## One deviation from the plan note, recorded

§10 wanted generated reads of the growing-key components (`attention_key`/`attention_scores`/`attention_probs`) served as "ragged per-step tensors". The value layer has no type for a per-step list whose sizes grow with the cache — `RaggedValue` is ragged over *positions*, not over a second axis — so both engines keep the shared axis-derived refusal, identical text (pinned). Serving them honestly needs a value-shape design first; flagging for D-review rather than papering over.

## Tests

Cross-engine parity for generated reads on both fixtures (module boundaries, the stackable interface slots q/z, `lm_head` via the shared ln_final-capture trick), identical decoded ids + addressed steps, a prefill write reaching the continuation identically on both engines, the greedy self-consistency pin (`argmax(lm_head at step i) == token i+1` — from the generation-frame handoff), the per-step DeltaNet state advancing every step and continuing from the prefill chunks, and the flipped N8 phase pin (now the behavior test it promised).

## Gates

- full suite: **2365 passed**
- **zero corpus-digest diff**
- canary green

Closes out the N5→N8 stack of the engine plan; §11's remaining beats (shim retirement, the efficiency roadmap behind the parity suite) are separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)