### PR TITLE
Round 3.2: the routed interior's slot components and the expert: sub-axis

### DIFF
--- a/causalab/neural/engines/nnsight_tracing/engine.py
+++ b/causalab/neural/engines/nnsight_tracing/engine.py
@@ -84,7 +84,10 @@ class NnsightEngine(Engine):
     # bind to; the experts module's only child is one shared act_fn).
     _ROUND_THREE_MOE_INTERIOR = frozenset(
         {
+            "expert_gate_proj",
+            "expert_up_proj",
             "expert_activation",
+            "expert_output",
         }
     )
     _UNDECLARED = _ROUND_TWO_ATTENTION | _ROUND_THREE_MOE_INTERIOR

--- a/causalab/neural/engines/pytorch_hooks/executor.py
+++ b/causalab/neural/engines/pytorch_hooks/executor.py
@@ -101,6 +101,9 @@ class PointExecutor(ExecutorBase):
 
         write_hooks = self._build_write_hooks(write_names, input_role, batch)
         capture: dict[tuple[int, str], torch.Tensor] = {}
+        # the routing table alongside each experts-interface capture — what the
+        # `expert:` sub-axis joins on (executor_base._expert_selected)
+        idx_capture: dict[TapKey, torch.Tensor] = {}
         capture_sites = {
             (rname): resolve_site(self.bundle, self.doc.sites[str(read.site)])
             for rname, read in taps
@@ -172,7 +175,9 @@ class PointExecutor(ExecutorBase):
                     experts.setdefault(id(site.module), []).append(
                         ExpertsTap(
                             slot=site.interface_slot,
-                            read=_experts_capture(capture, key, site, batch_size),
+                            read=_experts_capture(
+                                capture, idx_capture, key, site, batch_size
+                            ),
                         )
                     )
                     continue
@@ -218,7 +223,13 @@ class PointExecutor(ExecutorBase):
             site = capture_sites[rname]
             raw = capture[tap_key(site)]
             self._read_values[rname] = self._finalize_read(
-                rname, read, site, raw, batch, input_role
+                rname,
+                read,
+                site,
+                raw,
+                batch,
+                input_role,
+                expert_idx=idx_capture.get(tap_key(site)),
             )
 
         if depth:
@@ -271,6 +282,7 @@ class PointExecutor(ExecutorBase):
 
         tokens: list[torch.Tensor] = [nxt]
         steps: dict[TapKey, list[torch.Tensor]] = {}
+        idx_steps: dict[TapKey, list[torch.Tensor]] = {}
         cache = prefill.past_key_values
         with contextlib.ExitStack() as hooks:
             interface: dict[int, list[InterfaceTap]] = {}
@@ -284,10 +296,13 @@ class PointExecutor(ExecutorBase):
                 steps[key] = []
                 if site.kind == "experts":
                     assert site.interface_slot is not None
+                    idx_steps[key] = []
                     experts.setdefault(id(site.module), []).append(
                         ExpertsTap(
                             slot=site.interface_slot,
-                            read=_experts_accumulate(steps[key], site, batch_size),
+                            read=_experts_accumulate(
+                                steps[key], idx_steps[key], site, batch_size
+                            ),
                         )
                     )
                     continue
@@ -356,6 +371,11 @@ class PointExecutor(ExecutorBase):
             site = gen_sites[rname]
             capture_site = gen_capture_sites[rname]
             stacked = torch.cat(steps[tap_key(capture_site)], 1)
+            stacked_idx = (
+                torch.cat(idx_steps[tap_key(capture_site)], 1)
+                if idx_steps.get(tap_key(capture_site))
+                else None
+            )
             dataset_rows = self.role_rows[input_role]
             field = self.role_fields[input_role]
             per_row = [
@@ -385,6 +405,7 @@ class PointExecutor(ExecutorBase):
                 input_role,
                 per_row=per_row,
                 project=project,
+                expert_idx=stacked_idx,
             )
 
     # ------------------------------------------------------------------ #
@@ -465,6 +486,12 @@ def _interface_accumulate(
     return read
 
 
+def _contract_idx(idx: torch.Tensor, batch_size: int) -> torch.Tensor:
+    """The routing table in contract form: ``(tokens, top_k)`` token-major →
+    ``(batch, position, top_k)`` — the same split every flat_batch shape uses."""
+    return idx.reshape(batch_size, -1, idx.shape[-1])
+
+
 def _experts_edit(
     site: ResolvedSite, write: Callable[[torch.Tensor], None], batch_size: int
 ) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
@@ -472,46 +499,74 @@ def _experts_edit(
 
     Same contract as :func:`_interface_edit`: the manager hands out a clone in
     the taps' token-major form, this converts it to ``(batch, position,
-    feature)``, lets the shared write math mutate it, and converts back. The
-    routing table rides along unused here — round 3.2's ``expert`` sub-axis is
-    what consumes it.
+    feature)``, lets the shared write math mutate it, and converts back.
+
+    A site naming an ``expert`` writes only that expert's rows: the write math
+    runs over the whole contract tensor as usual, and the merge keeps its
+    result exactly where the routing table names that expert — an expert no
+    token chose therefore receives a write that lands nowhere, the data-fact
+    twin of the width-0 read.
     """
 
-    def edit(native: torch.Tensor, _idx: torch.Tensor) -> torch.Tensor:
+    def edit(native: torch.Tensor, idx: torch.Tensor) -> torch.Tensor:
         contract = to_contract(native, site.shape, batch_size=batch_size)
+        if site.expert is None:
+            write(contract)
+            return from_contract(
+                contract, site.shape, batch_size=batch_size, native=native
+            )
+        original = contract.clone()
         write(contract)
-        return from_contract(contract, site.shape, batch_size=batch_size, native=native)
+        idx_c = _contract_idx(idx, batch_size)  # (b, s, top_k)
+        top_k = idx_c.shape[-1]
+        per_slot = contract.shape[-1] // top_k
+        mask = (
+            (idx_c == site.expert)
+            .unsqueeze(-1)
+            .expand(*idx_c.shape, per_slot)
+            .reshape(contract.shape)
+        )
+        merged = torch.where(mask, contract, original)
+        return from_contract(merged, site.shape, batch_size=batch_size, native=native)
 
     return edit
 
 
 def _experts_capture(
     sink: dict[Any, torch.Tensor],
+    idx_sink: dict[Any, torch.Tensor],
     key: Any,
     site: ResolvedSite,
     batch_size: int,
 ) -> Callable[[torch.Tensor, torch.Tensor], None]:
-    """The read half — the same contract shape ``_capturing`` produces."""
+    """The read half — the same contract shape ``_capturing`` produces, plus
+    the routing table the ``expert:`` sub-axis joins on."""
 
-    def read(native: torch.Tensor, _idx: torch.Tensor) -> None:
+    def read(native: torch.Tensor, idx: torch.Tensor) -> None:
         sink[key] = to_contract(native, site.shape, batch_size=batch_size)
+        idx_sink[key] = _contract_idx(idx, batch_size)
 
     return read
 
 
 def _experts_accumulate(
-    sink: list[torch.Tensor], site: ResolvedSite, batch_size: int
+    sink: list[torch.Tensor],
+    idx_sink: list[torch.Tensor],
+    site: ResolvedSite,
+    batch_size: int,
 ) -> Callable[[torch.Tensor, torch.Tensor], None]:
     """The read half for a decode: append per step, as ``_accumulating`` does.
 
     Safe for every experts-interface shape: the interior is token-indexed, so a
     decode step is exactly one position per row and the steps stack on the
     position axis (unlike ``attention_key``, nothing here grows with the
-    prefix).
+    prefix). The routing table accumulates in lockstep — which experts each
+    *generated* token was sent to.
     """
 
-    def read(native: torch.Tensor, _idx: torch.Tensor) -> None:
+    def read(native: torch.Tensor, idx: torch.Tensor) -> None:
         sink.append(to_contract(native, site.shape, batch_size=batch_size))
+        idx_sink.append(_contract_idx(idx, batch_size))
 
     return read
 

--- a/causalab/neural/shared/executor_base.py
+++ b/causalab/neural/shared/executor_base.py
@@ -87,7 +87,7 @@ class RaggedValue:
 
 
 #: What identifies a tap for capture-sink sharing — see :func:`tap_key`.
-TapKey = tuple[int, str, FeatureShape, int | None, str | None]
+TapKey = tuple[int, str, FeatureShape, int | None, str | None, int | None]
 
 
 def tap_key(site: ResolvedSite) -> TapKey:
@@ -97,6 +97,10 @@ def tap_key(site: ResolvedSite) -> TapKey:
     different tuple element, or the same tensor read through a different shape
     — so the shape and tuple index are part of the identity. Keying on the
     module alone would let one tap read another's tensor.
+
+    ``expert`` is part of the identity for the write path's sake: two writes
+    at the same interior slot naming *different* experts must land as two
+    separately masked applications, and the address grouping keys on this.
     """
     return (
         id(site.module),
@@ -104,6 +108,7 @@ def tap_key(site: ResolvedSite) -> TapKey:
         site.shape,
         site.tuple_index,
         site.interface_slot,
+        site.expert,
     )
 
 
@@ -489,6 +494,7 @@ class ExecutorBase:
         *,
         per_row: list[list[int]] | None = None,
         project: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        expert_idx: torch.Tensor | None = None,
     ) -> "torch.Tensor | RaggedValue":
         """One read's value: gather at its positions, then featurize.
 
@@ -503,6 +509,8 @@ class ExecutorBase:
             return whole_native_tensor(rname, read, raw, site)
         if per_row is None:
             per_row = self._positions(read.pos, batch, input_role)
+        if site.expert is not None:
+            return self._expert_selected(rname, read, site, raw, expert_idx, per_row)
         gathered = self._gather(raw, per_row, f"read {rname!r}")
         if project is not None:
             if isinstance(gathered, RaggedValue):
@@ -533,6 +541,78 @@ class ExecutorBase:
             assert isinstance(gathered, RaggedValue)
             return RaggedValue(flat=value, widths=gathered.widths)
         return value
+
+    def _expert_selected(
+        self,
+        rname: str,
+        read: ReadSpec,
+        site: ResolvedSite,
+        raw: torch.Tensor,
+        expert_idx: torch.Tensor | None,
+        per_row: list[list[int]],
+    ) -> RaggedValue:
+        """The ragged face of the routed interior: the (position, slot) pairs
+        the router sent to ``site.expert``, as flat ``(selected, d)`` rows plus
+        per-example widths.
+
+        An expert no token chose returns width-0 rows — **a data fact, not an
+        error** (there is no per-expert hook to have not fired; the router
+        simply sent it nothing at these positions).
+
+        ``featurizer`` and ``dims`` are refused here rather than resized: the
+        document sized them against the token-major form (``top_k · d``), and
+        these rows are ``d``-wide — silently applying either would index a
+        different space than the author named.
+        """
+        if expert_idx is None:
+            raise ProtocolError(
+                "P2",
+                f"read {rname!r} selects expert {site.expert}, but the engine "
+                "captured no routing table alongside the tap — an executor bug, "
+                "not a document error",
+            )
+        if read.featurizer is not None:
+            raise ProtocolError(
+                "P4",
+                f"read {rname!r} featurizes the 'expert: {site.expert}' face of "
+                f"{site.component!r}, whose rows are d_expert-wide while the "
+                "component (and any featurizer sized against it) is top_k·d "
+                "wide. Featurize the token-major form — drop 'expert' — or read "
+                "this face raw.",
+            )
+        if isinstance(read.dims, tuple):
+            raise ProtocolError(
+                "P4",
+                f"read {rname!r} slices 'dims' on the 'expert: {site.expert}' "
+                f"face of {site.component!r}: 'dims' indexes the token-major "
+                "top_k·d axis, and these rows are d-wide. Drop 'expert' or "
+                "drop 'dims'.",
+            )
+        gathered = self._gather(raw, per_row, f"read {rname!r}")
+        idx_gathered = self._gather(expert_idx, per_row, f"read {rname!r}")
+        if isinstance(gathered, RaggedValue):
+            assert isinstance(idx_gathered, RaggedValue)
+            flat_value, pos_widths = gathered.flat, gathered.widths
+            flat_idx = idx_gathered.flat
+        else:
+            assert isinstance(idx_gathered, torch.Tensor)
+            rows, n_pos = gathered.shape[0], gathered.shape[1]
+            flat_value = gathered.reshape(rows * n_pos, gathered.shape[-1])
+            flat_idx = idx_gathered.reshape(rows * n_pos, idx_gathered.shape[-1])
+            pos_widths = (n_pos,) * rows
+        top_k = flat_idx.shape[-1]
+        per_slot = flat_value.shape[-1] // top_k
+        mask = flat_idx == site.expert  # (positions, top_k)
+        selected = flat_value.reshape(-1, top_k, per_slot)[mask]
+        counts = mask.sum(dim=-1)  # hits per (example, position) row
+        widths: list[int] = []
+        offset = 0
+        for width in pos_widths:
+            widths.append(int(counts[offset : offset + width].sum()))
+            offset += width
+        if not self.grad_enabled:
+            selected = selected.detach().cpu()
+        return RaggedValue(flat=selected, widths=tuple(widths))
 
     # ------------------------------------------------------------------ #
     # writes (the math; landing them is the engine's job)

--- a/causalab/neural/shared/sites.py
+++ b/causalab/neural/shared/sites.py
@@ -480,7 +480,10 @@ _MOE_COMPONENTS: frozenset[str] = frozenset(
         "shared_expert_activation",
         "shared_expert_output",
         "shared_expert_gate",
+        "expert_gate_proj",
+        "expert_up_proj",
         "expert_activation",
+        "expert_output",
     }
 )
 
@@ -492,7 +495,10 @@ _MOE_COMPONENTS: frozenset[str] = frozenset(
 #: shared ``act_fn``, which the wrapper hooks for the duration of that call).
 #: See :mod:`causalab.neural.engines.pytorch_hooks.experts_interface`.
 EXPERTS_FUNCTION_SLOTS: dict[str, str] = {
+    "expert_gate_proj": "gate_up",
+    "expert_up_proj": "gate_up",
     "expert_activation": "activation",
+    "expert_output": "down",
 }
 
 
@@ -532,19 +538,31 @@ def _moe_site(
             f"{sorted(name for name, _ in mlp.named_children())}) is not one — "
             "extend the tap table in pytorch_hooks/sites.py."
         )
-    # The `expert` sub-axis selects one of `num_experts` experts, which none of
-    # these tensors is indexed by: the router's axes are all-experts (logits) or
-    # top-k (scores, indices), and the shared expert is not one of the routed
-    # ones. Refusing beats silently ignoring it — the mistake `stream` made.
-    if spec.expert is not None:
+    # The `expert` sub-axis is the ragged face of the routed interior: select
+    # the (position, slot) pairs the router sent to one expert. Only the
+    # interior-slot components carry it — the router's own axes are all-experts
+    # (logits) or top-k (scores, indices), and the shared expert is not one of
+    # the routed experts, so `expert` on those is refused rather than silently
+    # ignored (the mistake `stream` made).
+    expert = spec.expert if isinstance(spec.expert, int) else None
+    if spec.expert is not None and component not in EXPERTS_FUNCTION_SLOTS:
         raise ProtocolError(
             "P4",
             f"site names expert {spec.expert!r} on component {component!r}, "
             "which has no per-expert axis: the router's axes are all-experts "
             "or top-k, and the shared expert is not one of the routed experts. "
-            "The 'expert' sub-axis lands with the interior-slot components "
-            "(round 3.2).",
+            "The per-expert interior components are 'expert_gate_proj', "
+            "'expert_up_proj', 'expert_activation' and 'expert_output'.",
         )
+    if expert is not None:
+        total = bundle.info.num_experts
+        if total is None or not 0 <= expert < total:
+            raise ProtocolError(
+                "P4",
+                f"site names expert {expert} on component {component!r}, but "
+                f"{bundle.key!r} routes over {total} experts — the sub-axis "
+                "selects one of them by its id.",
+            )
 
     shape = component_shape(bundle.info, component)
 
@@ -577,6 +595,7 @@ def _moe_site(
             component=component,
             shape=shape,
             interface_slot=EXPERTS_FUNCTION_SLOTS[component],
+            expert=expert,
         )
 
     def flat(module: Any, kind: str, tuple_index: int | None = None) -> ResolvedSite:
@@ -704,15 +723,6 @@ def resolve_site(bundle: Any, spec: SiteSpec) -> ResolvedSite:
         # form, which is what makes the executor refuse to gather or featurize
         # it without any component name appearing in that refusal.
         return tap(_attn(bundle, layer), "out", tuple_index=1, interface_slot="probs")
-    if component == "expert_output":
-        raise NotImplementedError(
-            f"the pytorch_hooks engine has no tap for {component!r} yet — "
-            "expert_output names the per-expert loop interior, which needs the "
-            "ragged value shape (follow-up F2). The rest of the MoE surface — "
-            "the router, the combined routed output and the shared expert — "
-            "resolves; see _moe_site (sites.py)."
-        )
-
     block = _blocks(bundle)[layer]
     if component == "attention_input_norm":
         # input_layernorm's OUTPUT: what the mixer actually consumes

--- a/causalab/protocol/plan.py
+++ b/causalab/protocol/plan.py
@@ -105,8 +105,10 @@ COMPONENT_RANK: dict[str, int] = {
     # and the down-projection's (pre-routing-weight) output keeps its reserved
     # 540 — all between `expert_idx` and `routed_output`, forward order, no
     # renumbering.
+    "expert_gate_proj": 532,
+    "expert_up_proj": 534,
     "expert_activation": 536,
-    "expert_output": 540,  # per-expert interior (the rest lands in round 3.2)
+    "expert_output": 540,  # the down-projection's output, before the routing weight
     "routed_output": 550,
     "mlp_activation": 600,
     # the shared expert runs beside the routed ones; its gate is *consumed*

--- a/causalab/protocol/registry.py
+++ b/causalab/protocol/registry.py
@@ -23,8 +23,14 @@ component                            shape
 ``block_output``, ``attention_output``,   residual stream. The three norm taps
 ``mlp_input``, ``mlp_output``,       are here because an RMSNorm maps the
 ``ln_final``, ``attention_input_norm``,   residual stream to itself, so both
-``block_mid``, ``mlp_input_norm``,   its sides are hidden-wide
-``expert_output``
+``block_mid``, ``mlp_input_norm``    its sides are hidden-wide
+``expert_gate_proj``,                ``(batch·position, top_k·moe_inner)``,
+``expert_up_proj``,                  token-major and **ranking**: slot *k* is
+``expert_activation``                the *k*-th ranked expert (the two proj
+                                     halves share one fused capture)
+``expert_output``                    ``(batch·position, top_k·hidden)``,
+                                     token-major, ranking; the value is
+                                     pre-routing-weight
 ``mlp_activation``                   ``(batch, position, intermediate)`` (the
                                      family caveat of *which* tensor this
                                      names lives in the backend, not here)
@@ -196,7 +202,6 @@ _HIDDEN_COMPONENTS: frozenset[str] = frozenset(
         "mlp_input",
         "mlp_output",
         "ln_final",
-        "expert_output",
         "attention_input_norm",
         "block_mid",
         "mlp_input_norm",
@@ -376,6 +381,49 @@ def component_shape(info: ModelInfo, component: str) -> FeatureShape:
                 "fitted across positions is fitted across a shuffled basis. "
                 "Read it directly, or featurize 'router_logits', whose axis is "
                 "the fixed all-experts one."
+            ),
+        )
+    if component in ("expert_gate_proj", "expert_up_proj"):
+        # the two halves of the routed up-projection's fused [gate_e | up_e]
+        # output — one capture, two addresses (the `attention_gate` precedent),
+        # token-major and ranked like the rest of the interior
+        if info.num_experts_per_tok is None or info.moe_intermediate_size is None:
+            raise ValidationError(
+                4,
+                f"model {info.key!r} declares no routed-expert inner width "
+                f"(moe_intermediate_size) or top-k; {component} has no width",
+            )
+        return shapes.flat_topk_fused_features(
+            info.num_experts_per_tok,
+            2,
+            0 if component == "expert_gate_proj" else 1,
+            info.moe_intermediate_size,
+            ranking=True,
+            note=(
+                "Its slot axis is a per-token ranking (see 'expert_activation'); "
+                "join slots to experts through 'expert_idx'."
+            ),
+        )
+    if component == "expert_output":
+        # the down-projection's output BEFORE the routing weight — hidden-wide
+        # per (token, slot), token-major. The registry identity:
+        # routed_output == sum over slots of expert_output · router_scores,
+        # exact (the model computes precisely this sum, in this order).
+        if info.num_experts_per_tok is None:
+            raise ValidationError(
+                4,
+                f"model {info.key!r} declares no num_experts_per_tok; "
+                f"{component} has no width",
+            )
+        return shapes.flat_topk_features(
+            info.num_experts_per_tok,
+            info.hidden_size,
+            ranking=True,
+            note=(
+                "Its slot axis is a per-token ranking (see 'expert_activation'); "
+                "join slots to experts through 'expert_idx'. The value is "
+                "pre-routing-weight: routed_output == the slot-sum of "
+                "expert_output · router_scores."
             ),
         )
     if component == "expert_activation":

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -121,6 +121,8 @@ Component = Literal[
     "router_logits",
     "router_scores",
     "expert_idx",
+    "expert_gate_proj",
+    "expert_up_proj",
     "expert_activation",
     "expert_output",
     "routed_output",

--- a/causalab/protocol/shapes.py
+++ b/causalab/protocol/shapes.py
@@ -83,6 +83,7 @@ __all__ = [
     "flat_td",
     "flat_topk",
     "flat_topk_features",
+    "flat_topk_fused_features",
 ]
 
 #: What one axis of a tapped tensor means.
@@ -405,6 +406,37 @@ def flat_topk_features(
     return FeatureShape(
         axes=(_BATCH, _POSITION, Axis("topk", k), Axis("feature", width)),
         flat_batch=True,
+        ranking=ranking,
+        note=note,
+    )
+
+
+def flat_topk_fused_features(
+    k: int,
+    splits: int,
+    index: int,
+    width: int,
+    *,
+    ranking: bool = False,
+    note: str | None = None,
+) -> FeatureShape:
+    """``(batch*position, k·splits·width)``, naming one split per slot.
+
+    The routed experts' up-projection emits ``[gate_e | up_e]`` per (token,
+    slot) pair in one tensor; ``expert_gate_proj`` is split 0 and
+    ``expert_up_proj`` split 1 — one capture, two addresses, the
+    ``attention_gate`` precedent with a top-k axis in front.
+    """
+    return FeatureShape(
+        axes=(
+            _BATCH,
+            _POSITION,
+            Axis("topk", k),
+            Axis("fused", splits),
+            Axis("feature", width),
+        ),
+        flat_batch=True,
+        fused_index=index,
         ranking=ranking,
         note=note,
     )

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -279,8 +279,8 @@ execution order:
 `attention_key` · `attention_scores` · `attention_z` · `attention_result` ·
 `attention_output` · `attention_premix` · `attention_probs` · `block_mid` ·
 `mlp_input_norm` · `mlp_input` · `router_logits` · `router_scores` ·
-`expert_idx` · `expert_activation` · `expert_output` · `routed_output` ·
-`mlp_activation` ·
+`expert_idx` · `expert_gate_proj` · `expert_up_proj` · `expert_activation` ·
+`expert_output` · `routed_output` · `mlp_activation` ·
 `shared_expert_gate_proj` · `shared_expert_up_proj` ·
 `shared_expert_activation` · `shared_expert_output` · `shared_expert_gate` ·
 `mlp_output` · `block_output` · `ln_final` · `lm_head`
@@ -318,9 +318,21 @@ execution order:
   family — represented **token-major**: `(batch·position, top_k · d_expert)`,
   slot *k* the *k*-th ranked expert, joined to experts through `expert_idx`.
   Its slot axis is a ranking, like `router_scores`, with the same
-  basis-fitting refusal. The remaining interior slots (`expert_gate_proj`,
-  `expert_up_proj`, `expert_output`) and the ragged `expert:` sub-axis land
-  with round 3.2.
+  basis-fitting refusal — and so are the other interior slots:
+  `expert_gate_proj` and `expert_up_proj` are the two halves of the fused
+  `[gate_e | up_e]` projection (one capture, two addresses — the
+  `attention_gate` precedent), and `expert_output` is the down-projection's
+  output **before** the routing weight, pinned by the identity
+  `routed_output == Σ_slot expert_output · router_scores` (exactly, 0.0).
+- **`expert: e` is the ragged face of the routed interior.** On the four
+  interior components it selects the (position, slot) pairs the router sent to
+  expert *e* and returns flat rows plus per-example widths (a ragged value);
+  an expert no token chose returns width-0 rows — a data fact, not an error.
+  A write under `expert: e` lands only on that expert's rows (and therefore
+  lands nowhere when no addressed token chose it). `featurizer`/`dims` are
+  refused on this face: they are sized against the token-major `top_k · d`
+  axis and these rows are `d`-wide. On every other MoE component `expert`
+  is still refused — those tensors have no per-expert axis.
 - **`expert_idx` is a routing table, not a feature space** — the same rule as
   `input_ids`: integer ids, no featurizer, no width. And `router_scores` has a
   width but its axis is a per-token **ranking**, not a basis: column *k* is the

--- a/tests/neural/engines/pytorch_hooks/test_sites_round1_moe.py
+++ b/tests/neural/engines/pytorch_hooks/test_sites_round1_moe.py
@@ -3,7 +3,7 @@
 PR3 of the hookpoint-vocabulary stack. Nine components, every one a plain module
 output or input (§2.1) — the router is a module returning a 3-tuple and the
 experts are a fused module, so nothing here needs the ragged value shape that
-the per-expert interior does (that is ``expert_output``, follow-up F2).
+the per-expert interior does (that is round 3's ``expert_output``).
 
 Two kinds of assertion, as in PR2. Shapes are 📐 measurements against a real
 ``qwen3_5_moe`` checkpoint, so a mismatch is a finding. Identities are stronger:
@@ -237,14 +237,6 @@ def test_an_expert_sub_axis_refuses(qwen35moe_bundle):
             SiteSpec(component="router_scores", layer=0, expert=3),
         )
     assert "no per-expert axis" in str(excinfo.value)
-
-
-def test_expert_output_still_refuses_and_says_why(qwen35moe_bundle):
-    """The per-expert interior is follow-up F2, and its refusal must not read
-    like the router's (which now resolves)."""
-    with pytest.raises(NotImplementedError) as excinfo:
-        resolve_site(qwen35moe_bundle, SiteSpec(component="expert_output", layer=0))
-    assert "ragged" in str(excinfo.value)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/neural/engines/pytorch_hooks/test_sites_round3_moe_interior.py
+++ b/tests/neural/engines/pytorch_hooks/test_sites_round3_moe_interior.py
@@ -425,15 +425,6 @@ def test_head_is_refused_because_nothing_here_has_heads(qwen35moe_bundle):
         )
 
 
-def test_the_expert_sub_axis_is_not_claimed_yet(qwen35moe_bundle):
-    """Round 3.2's surface, refused rather than ignored until it lands."""
-    with pytest.raises(ProtocolError, match="round 3.2"):
-        resolve_site(
-            qwen35moe_bundle,
-            SiteSpec(component="expert_activation", layer=MOE_LAYER, expert=3),
-        )
-
-
 def test_a_dense_mlp_family_is_refused_architecturally():
     bundle = load_model(TINY_LLAMA)
     with pytest.raises(NotImplementedError, match="sparse-MoE"):
@@ -450,3 +441,246 @@ def test_the_shape_declares_the_fixtures_widths(qwen35moe_bundle):
     assert shape.ranking is True
     assert shape.flat_batch is True
     assert shape.head_space is None
+
+
+# --------------------------------------------------------------------------- #
+# round 3.2 — the interface-slot components
+# --------------------------------------------------------------------------- #
+
+INTERIOR = (
+    "expert_gate_proj",
+    "expert_up_proj",
+    "expert_activation",
+    "expert_output",
+)
+
+#: 📐 token-major contract widths on the fixture: the projection halves and the
+#: activation are moe_intermediate_size (32) per slot, the down-projection's
+#: output is hidden (8) per slot.
+INTERIOR_WIDTH = {
+    "expert_gate_proj": TOP_K * D_EXPERT,
+    "expert_up_proj": TOP_K * D_EXPERT,
+    "expert_activation": TOP_K * D_EXPERT,
+    "expert_output": TOP_K * 8,
+}
+
+
+def _hit_and_missing_expert(bundle: ModelBundle) -> tuple[int, int]:
+    """One expert the router chose often at these tokens, and one it never did
+    (📐 40 of 128 experts are hit on the 5-token prompt, so both exist)."""
+    doc = _read_doc("expert_idx")
+    idx = executor_for(doc, bundle, base_texts=[TEXT]).read_value("idx" and "r")
+    chosen = set(int(x) for x in idx.reshape(-1))
+    hit = int(idx.reshape(-1).mode().values)
+    missing = next(i for i in range(128) if i not in chosen)
+    return hit, missing
+
+
+@pytest.mark.parametrize("component", INTERIOR)
+def test_every_interior_component_resolves_and_reads(qwen35moe_bundle, component):
+    site = resolve_site(
+        qwen35moe_bundle, SiteSpec(component=component, layer=MOE_LAYER)
+    )
+    assert site.kind == "experts"
+    value = executor_for(
+        _read_doc(component), qwen35moe_bundle, base_texts=[TEXT]
+    ).read_value("r")
+    assert tuple(value.shape) == (1, 5, INTERIOR_WIDTH[component])
+
+
+def test_the_projection_halves_share_one_fused_capture(qwen35moe_bundle):
+    """The `attention_gate` precedent with a top-k axis in front: gate and up
+    are chunks of one projection output, and the registry identity
+    ``expert_activation == act_fn(expert_gate_proj)`` pins which chunk is
+    which — exactly, because the model's own SiLU is deterministic."""
+    doc = _read_doc("expert_gate_proj")
+    doc["sites"]["act"] = {"component": "expert_activation", "layer": MOE_LAYER}
+    doc["reads"]["a"] = {
+        "site": "act",
+        "pos": "all",
+        "model": "original",
+        "input": "base",
+    }
+    doc["save"].append(
+        {
+            "value": "a",
+            "model": "original",
+            "input": "base",
+            "file_path": "b.safetensors",
+        }
+    )
+    executor = executor_for(doc, qwen35moe_bundle, base_texts=[TEXT])
+    gate, act = executor.read_value("r"), executor.read_value("a")
+    torch.testing.assert_close(torch.nn.functional.silu(gate), act, atol=0.0, rtol=0.0)
+
+
+def test_the_registry_identity_reconstructs_routed_output_exactly(qwen35moe_bundle):
+    """The docstring identity, asserted: ``routed_output == Σ_slot
+    expert_output · router_scores`` — at exactly 0.0, because the model computes
+    precisely this sum in this order. 📐 This is also the tie-order guard on the
+    recomputed sort: rows attributed to the wrong tokens would break it loudly."""
+    doc = _read_doc("expert_output")
+    doc["sites"]["scores"] = {"component": "router_scores", "layer": MOE_LAYER}
+    doc["sites"]["routed"] = {"component": "routed_output", "layer": MOE_LAYER}
+    for name, site in (("s", "scores"), ("o", "routed")):
+        doc["reads"][name] = {
+            "site": site,
+            "pos": "all",
+            "model": "original",
+            "input": "base",
+        }
+        doc["save"].append(
+            {
+                "value": name,
+                "model": "original",
+                "input": "base",
+                "file_path": f"{name}.safetensors",
+            }
+        )
+    executor = executor_for(doc, qwen35moe_bundle, base_texts=[TEXT])
+    out = executor.read_value("r").reshape(1, 5, TOP_K, 8)
+    scores = executor.read_value("s").reshape(1, 5, TOP_K, 1)
+    routed = executor.read_value("o")
+    torch.testing.assert_close((out * scores).sum(2), routed, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("component", ("expert_gate_proj", "expert_output"))
+def test_interior_writes_hold_the_identity_bar(qwen35moe_bundle, component):
+    """swap-with-own-value is exactly 0.0 through the fused scatter and the
+    re-sort; a counterfactual swap moves the logits (📐 expert_out +1 moved
+    them by 1.53 in the probe)."""
+    doc = _write_doc(component, {"swap": "v_cf"})
+    doc["reads"]["v_cf"]["input"] = "base"
+    assert _moved(qwen35moe_bundle, doc) == 0.0
+    assert _moved(qwen35moe_bundle, _write_doc(component, {"swap": "v_cf"})) > 1e-4
+
+
+# --------------------------------------------------------------------------- #
+# round 3.2 — the `expert:` sub-axis
+# --------------------------------------------------------------------------- #
+
+
+def test_the_expert_face_selects_exactly_the_routed_pairs(qwen35moe_bundle):
+    """The ragged face against a manual join: rows where ``expert_idx == e``,
+    in (position, slot) order, at exactly 0.0."""
+    from causalab.neural.shared.executor_base import RaggedValue
+
+    hit, _ = _hit_and_missing_expert(qwen35moe_bundle)
+    doc = _read_doc("expert_activation")
+    doc["sites"]["idxs"] = {"component": "expert_idx", "layer": MOE_LAYER}
+    doc["reads"]["i"] = {
+        "site": "idxs",
+        "pos": "all",
+        "model": "original",
+        "input": "base",
+    }
+    doc["save"].append(
+        {
+            "value": "i",
+            "model": "original",
+            "input": "base",
+            "file_path": "i.safetensors",
+        }
+    )
+    executor = executor_for(doc, qwen35moe_bundle, base_texts=[TEXT])
+    full, idx = executor.read_value("r"), executor.read_value("i")
+
+    faced = _read_doc("expert_activation")
+    faced["sites"]["tap"]["expert"] = hit
+    value = executor_for(faced, qwen35moe_bundle, base_texts=[TEXT]).read_value("r")
+    assert isinstance(value, RaggedValue)
+    mask = idx.reshape(1, 5, TOP_K) == hit
+    manual = full.reshape(1, 5, TOP_K, D_EXPERT)[mask]
+    assert value.widths == (int(mask.sum()),)
+    torch.testing.assert_close(value.flat, manual, atol=0.0, rtol=0.0)
+
+
+def test_an_expert_no_token_chose_reads_as_width_zero(qwen35moe_bundle):
+    """The honest form of the never-fired-hook question: there is no hook to
+    not-fire. The router simply sent this expert nothing at these positions,
+    and the read says so as data — width-0 rows, no error."""
+    from causalab.neural.shared.executor_base import RaggedValue
+
+    _, missing = _hit_and_missing_expert(qwen35moe_bundle)
+    doc = _read_doc("expert_activation")
+    doc["sites"]["tap"]["expert"] = missing
+    value = executor_for(doc, qwen35moe_bundle, base_texts=[TEXT]).read_value("r")
+    assert isinstance(value, RaggedValue)
+    assert value.widths == (0,)
+    assert tuple(value.flat.shape) == (0, D_EXPERT)
+
+
+def test_a_write_under_expert_lands_only_on_that_experts_rows(qwen35moe_bundle):
+    """Doubling one hit expert's activations moves the logits; the same write
+    aimed at an unchosen expert lands nowhere — exactly 0.0, the data-fact twin
+    of the width-0 read."""
+    hit, missing = _hit_and_missing_expert(qwen35moe_bundle)
+
+    def masked_doc(expert: int) -> dict:
+        doc = _write_doc(
+            "expert_activation", {"add_scaled": {"op": "v_cf", "alpha": 1.0}}
+        )
+        doc["sites"]["tap"]["expert"] = expert
+        # the operand reads the token-major form: the write site owns the mask
+        doc["sites"]["whole"] = {"component": "expert_activation", "layer": MOE_LAYER}
+        doc["reads"]["v_cf"] = {
+            "site": "whole",
+            "pos": "all",
+            "model": "original",
+            "input": "base",
+        }
+        return doc
+
+    assert _moved(qwen35moe_bundle, masked_doc(hit)) > 1e-4
+    assert _moved(qwen35moe_bundle, masked_doc(missing)) == 0.0
+
+
+def test_the_expert_face_reads_in_the_generated_frame(qwen35moe_bundle):
+    """D7 extends to the ragged face: the routing table accumulates per decode
+    step, so the face selects over the generated tokens' own routing."""
+    from causalab.neural.shared.executor_base import RaggedValue
+
+    hit, _ = _hit_and_missing_expert(qwen35moe_bundle)
+    doc = _read_doc("expert_output")
+    doc["sites"]["tap"]["expert"] = hit
+    doc["positions"] = {"window": {"generated": {"max_new_tokens": 3}, "all": True}}
+    doc["reads"]["r"]["pos"] = "window"
+    value = executor_for(doc, qwen35moe_bundle, base_texts=[TEXT]).read_value("r")
+    assert isinstance(value, RaggedValue)
+    assert len(value.widths) == 1
+    assert value.flat.shape[-1] == 8  # hidden-wide rows
+
+
+def test_expert_bounds_are_refused_by_name(qwen35moe_bundle):
+    with pytest.raises(ProtocolError, match="128 experts"):
+        resolve_site(
+            qwen35moe_bundle,
+            SiteSpec(component="expert_activation", layer=MOE_LAYER, expert=128),
+        )
+
+
+def test_expert_on_a_router_component_is_still_refused(qwen35moe_bundle):
+    with pytest.raises(ProtocolError, match="no per-expert axis"):
+        resolve_site(
+            qwen35moe_bundle,
+            SiteSpec(component="router_scores", layer=MOE_LAYER, expert=3),
+        )
+
+
+@pytest.mark.parametrize(
+    "field, value", [("featurizer", "f"), ("dims", [0, 1])], ids=["featurizer", "dims"]
+)
+def test_featurizer_and_dims_are_refused_on_the_expert_face(
+    qwen35moe_bundle, field, value
+):
+    """Both are sized against the token-major ``top_k · d`` axis, and the face's
+    rows are ``d``-wide — applying either would index a different space than
+    the author named."""
+    hit, _ = _hit_and_missing_expert(qwen35moe_bundle)
+    doc = _read_doc("expert_activation")
+    doc["sites"]["tap"]["expert"] = hit
+    if field == "featurizer":
+        doc["featurizers"] = {"f": {"kind": "standardize"}}
+    doc["reads"]["r"][field] = value
+    with pytest.raises(ProtocolError, match="expert"):
+        executor_for(doc, qwen35moe_bundle, base_texts=[TEXT]).read_value("r")

--- a/tests/protocol/test_registry_shapes.py
+++ b/tests/protocol/test_registry_shapes.py
@@ -106,10 +106,13 @@ EXPECTED: dict[str, tuple[int | None, int | None, bool]] = {
     "router_logits": (32, None, True),
     "router_scores": (4, None, True),
     "expert_idx": (4, None, False),
-    # token-major routed interior: top_k (4) slots of moe_intermediate_size
-    # (24) features each, on a ranking axis
+    # token-major routed interior: top_k (4) slots, on a ranking axis. The two
+    # projection halves and the activation are moe_intermediate_size (24) wide
+    # per slot; the down-projection's output is hidden (64) wide per slot.
+    "expert_gate_proj": (4 * 24, None, True),
+    "expert_up_proj": (4 * 24, None, True),
     "expert_activation": (4 * 24, None, True),
-    "expert_output": (64, None, True),
+    "expert_output": (4 * 64, None, True),
     "routed_output": (64, None, True),
     "shared_expert_gate_proj": (48, None, True),
     "shared_expert_up_proj": (48, None, True),


### PR DESCRIPTION
Stacked on #69. Lands by deleting refusals (the #53-discharging-#50 shape): `expert_output`'s round-1 `NotImplementedError` goes, its reserved rank 540 is claimed, and `expert` stops being refused on the interior components.

- `expert_gate_proj` / `expert_up_proj`: the two fused halves of the one `[gate_e | up_e]` capture (the `attention_gate` precedent with a top-k axis in front); a write to one half scatters back without disturbing the other (0.0).
- `expert_output`: the down-projection's output **before** the routing weight, moved out of the hidden-wide set to token-major `(b·s, top_k · hidden)`. The registry states — and the suite asserts — `routed_output == Σ_slot expert_output · router_scores` at exactly 0.0, which doubles as the tie-order guard on the recomputed sort.
- **`expert: e`** is the ragged face of the same tensors: the (position, slot) pairs the router sent to expert *e*, as a `RaggedValue`. An expert no token chose reads as width-0 rows and receives writes that land nowhere — a data fact, not an error (the honest form of the never-fired-hook question). Writes merge through a routing-table mask (a doubling aimed at an unchosen expert moves the logits by exactly 0.0). `featurizer`/`dims` refuse on the face (sized against `top_k·d`, the face is `d`-wide). `tap_key` gains the expert so two writes naming different experts land as two masked applications.
- Generated frames: the routing table accumulates per decode step alongside the value (D7).

Suite: 2274 passed; corpus digests zero-diff.

Plan: vault note `causalab-round3-4-plan` §2.1/§3, decisions D1/D2 as recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)