### PR TITLE
Split Jupyter-only deps into a notebook extra (port of internal #539)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,6 @@ dependencies = [
     "pandas",
     "numpy",
     "scikit-learn",
-    "ipywidgets",
-    "jupyterlab",
-    "ipycytoscape",
     "seaborn",
     # 5.16 is the first release carrying models/qwen3_5_moe (Qwen3.6-35B-A3B's
     # text tower); the hookpoint vocabulary work targets that architecture.
@@ -26,9 +23,7 @@ dependencies = [
     "tensorboard",
     "dash",
     "dash-cytoscape",
-    "jupyter-dash",
     "rich",
-    "ipykernel>=7.0.1",
     "umap-learn>=0.5.0",
     "pot>=0.9.0",
     "openai>=1.50.0",
@@ -78,6 +73,19 @@ module-name = ["causalab"]
 module-root = ""
 
 [project.optional-dependencies]
+# Interactive/Jupyter-only additions: nothing in causalab/, tests/, scripts/ or
+# research/ imports these (dash + dash-cytoscape stay core —
+# causalab.io.plots.causal_graph imports dash at module level). Split out so
+# headless installs (e.g. the silico cluster-job GPU image, where causalab is
+# merged into a network-less job venv) don't carry the jupyter-server stack.
+# Ported from causalab-internal #539 after the intervention-protocol sync.
+notebook = [
+    "ipywidgets",
+    "jupyterlab",
+    "ipycytoscape",
+    "jupyter-dash",
+    "ipykernel>=7.0.1",
+]
 # The nnsight tracing engine (causalab/neural/engines/nnsight_tracing/).
 # Pinned to the 0.8-branch rev the engine was verified against on the real
 # Qwen3.6-35B-A3B (cockpit notes/causalab-nnsight-engine-plan.md §0 decision 1;

--- a/uv.lock
+++ b/uv.lock
@@ -379,11 +379,6 @@ dependencies = [
     { name = "dash" },
     { name = "dash-cytoscape" },
     { name = "datasets" },
-    { name = "ipycytoscape" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
-    { name = "jupyter-dash" },
-    { name = "jupyterlab" },
     { name = "matplotlib" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -410,6 +405,13 @@ dependencies = [
 nnsight = [
     { name = "nnsight" },
 ]
+notebook = [
+    { name = "ipycytoscape" },
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-dash" },
+    { name = "jupyterlab" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -434,11 +436,11 @@ requires-dist = [
     { name = "dash" },
     { name = "dash-cytoscape" },
     { name = "datasets", specifier = ">=2.20.0" },
-    { name = "ipycytoscape" },
-    { name = "ipykernel", specifier = ">=7.0.1" },
-    { name = "ipywidgets" },
-    { name = "jupyter-dash" },
-    { name = "jupyterlab" },
+    { name = "ipycytoscape", marker = "extra == 'notebook'" },
+    { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=7.0.1" },
+    { name = "ipywidgets", marker = "extra == 'notebook'" },
+    { name = "jupyter-dash", marker = "extra == 'notebook'" },
+    { name = "jupyterlab", marker = "extra == 'notebook'" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "nnsight", marker = "extra == 'nnsight'", git = "https://github.com/ndif-team/nnsight.git?rev=8c480727" },
@@ -458,7 +460,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.16" },
     { name = "umap-learn", specifier = ">=0.5.0" },
 ]
-provides-extras = ["nnsight"]
+provides-extras = ["notebook", "nnsight"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Re-port of [causalab-internal #539](https://github.com/goodfire-ai/causalab-internal/pull/539) (@ryan-goodfire) onto the intervention-protocol tree, following the [public→internal sync](https://github.com/goodfire-ai/causalab-internal/pull/545) that superseded it. The pyvene half of #539 is moot — pyvene is no longer a dependency.

**What**: `ipywidgets`, `jupyterlab`, `ipycytoscape`, `jupyter-dash`, `ipykernel` move from core deps to a `notebook` extra. `dash`/`dash-cytoscape` stay core (`causalab.io.plots.causal_graph` imports dash at module level).

**Why**: the original motivation stands on the new tree — headless installs (the silico cluster-job GPU image merges causalab into a network-less job venv) shouldn't carry the jupyter-server stack.

**Verified**:
- `grep` over `causalab/ tests/ scripts/ research/`: zero imports of the five packages (module-level or lazy)
- `uv export --frozen`: 0/5 in the default dependency set, 5/5 with `--extra notebook`
- `uv lock --check` passes → CI's `uv sync --frozen` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)