### PR TITLE
Refuse a write operand read from deeper than it lands (§5.20)

### DIFF
--- a/causalab/protocol/errors.py
+++ b/causalab/protocol/errors.py
@@ -35,7 +35,7 @@ __all__ = [
 #: How many rules the §5 load-error checklist has. Named so the range guard
 #: below and the spec move together: adding a rule means editing §5 and this
 #: number, and nothing else.
-CHECKLIST_RULES: int = 19
+CHECKLIST_RULES: int = 20
 
 
 class ProtocolError(ValueError):

--- a/causalab/protocol/plan.py
+++ b/causalab/protocol/plan.py
@@ -38,6 +38,7 @@ __all__ = [
     "interned_groups",
     "plan_point",
     "closure_digest",
+    "site_depth",
 ]
 
 #: Intra-block execution order of the component vocabulary — engine-free
@@ -45,8 +46,9 @@ __all__ = [
 #: and ``lm_head`` sort after every block.
 #:
 #: **Numbered in hundreds, with the attention band deliberately spread.** The
-#: values are ordinal and nothing outside this table reads them, but changing
-#: one changes group elision and therefore every closure digest — so the point
+#: values are ordinal — only their order is ever read, never the numbers — but
+#: changing one changes group elision, therefore every closure digest, and the
+#: operand-reachability comparison (§5.20, via :func:`site_depth`); so the point
 #: of the spacing is that inserting a component never renumbers an existing one.
 #: The attention interior is where the vocabulary is still growing (round 2 adds
 #: the pre-RoPE projections, the gate, the post-RoPE q/k, the scores, the mixer
@@ -320,7 +322,7 @@ def _build_group(
     data_identity: Mapping[str, Any] | None,
 ) -> ForwardGroup:
     taps = tuple(
-        Tap(read=rname, site=str(read.site), depth=_depth(doc, str(read.site)))
+        Tap(read=rname, site=str(read.site), depth=site_depth(doc, str(read.site)))
         for rname, read in doc.reads.items()
         if read.model == model and str(read.input) == input_role
     )
@@ -414,7 +416,22 @@ def closure_digest(
     ).hexdigest()
 
 
-def _depth(doc: Document, site_name: str) -> tuple[int, int]:
+def site_depth(doc: Document, site_name: str) -> tuple[int, int]:
+    """One site's position in the forward pass, as a sortable ``(layer, rank)``.
+
+    The total order the whole vocabulary shares: block depth first, then
+    :data:`COMPONENT_RANK` inside the block, with the two layer-less trunk
+    components sorting after every block. Two readers depend on it, and on
+    nothing finer:
+
+    * group elision (§4) — a forward may stop after its deepest tap;
+    * operand reachability (§5.20) — a write's operand may not be read from
+      strictly deeper than the address it lands on.
+
+    A non-integer ``layer`` (an unexpanded sweep or artifact wrapper) reads as
+    0. Both callers run on a *point* document, where every layer is concrete,
+    so that fallback is a type-narrowing convenience and not a semantic.
+    """
     site = doc.sites[site_name]
     layer = site.layer if isinstance(site.layer, int) else 0
     component = site.component if isinstance(site.component, str) else "lm_head"

--- a/causalab/protocol/validate.py
+++ b/causalab/protocol/validate.py
@@ -28,6 +28,16 @@ Interpretations this module commits to (each surfaced in the PR notes):
 * **Dead declarations** (§0) are reported under rule 11 — the sink rule
   names reads explicitly; unused sites, positions, featurizers and params
   are the same principle and share the rule number.
+* **Rule 20 refuses the uninterpretable, not the unexecutable.** A write
+  whose operand is read from strictly deeper than the write's own address is
+  perfectly runnable — the operand's model runs first, and §2.9's acyclicity
+  is what makes that staging legal. It is refused because no edge of the
+  network carries information from the source to the target, so the number
+  it produces is attributable to no path. Equal depth stays legal: that is
+  the two-pass harvest/inject idiom (corpus 03), where the value is injected
+  at the very address it was read from. The comparison is the same
+  ``(layer, rank)`` order group elision uses, so it is block-order aware —
+  a same-layer head → MLP operand is upstream, and the reverse is not.
 """
 
 from __future__ import annotations
@@ -36,6 +46,7 @@ import re
 from typing import Any, Iterable
 
 from causalab.protocol.errors import ValidationError
+from causalab.protocol.plan import site_depth
 from causalab.protocol.schema import (
     ADDITIVE_MECHANISMS,
     FEATURIZER_SLOTS,
@@ -70,7 +81,7 @@ _TRAINABLE_KINDS = frozenset({"subspace", "gate", "sae"})
 
 
 def validate_document(doc: Document, *, engine_is_local: bool | None = None) -> None:
-    """Run checklist rules 3–13, 16 and 17 (13 only when ``engine_is_local``
+    """Run checklist rules 3–13, 16, 17 and 20 (13 only when ``engine_is_local``
     is given). Raises :class:`ValidationError` on the first violation."""
     names = _check_namespace(doc)  # rule 3
     _check_references(doc, names)  # rule 4 (+ the rule-5 read bindings)
@@ -82,6 +93,7 @@ def validate_document(doc: Document, *, engine_is_local: bool | None = None) -> 
     _check_trainability(doc)  # rule 12
     _check_generation(doc)  # rule 16
     _check_model_realization(doc)  # rule 17
+    _check_operand_reachability(doc)  # rule 20
     if engine_is_local is not None:
         _check_pytorch_fn(doc, engine_is_local)  # rule 13
 
@@ -1067,4 +1079,52 @@ def _check_model_realization(doc: Document) -> None:
                 )
                 + " (§2.1)",
                 path=f"model.quantization.{field}",
+            )
+
+
+# --------------------------------------------------------------------------- #
+# rule 20 — a write's operand is reachable from its address
+# --------------------------------------------------------------------------- #
+
+
+def _site_label(doc: Document, site_name: str) -> str:
+    """``block_mid`` at layer 11, the way a refusal should name an address."""
+    site = doc.sites[site_name]
+    layer = site.layer
+    where = f" layer {layer}" if isinstance(layer, int) else ""
+    return f"site {site_name!r} ({site.component}{where})"
+
+
+def _check_operand_reachability(doc: Document) -> None:
+    """Refuse a write whose operand is read strictly deeper than it lands.
+
+    The value is *computable* — §2.9 stages the operand's model first — but
+    the network has no edge from the deeper address to the shallower one, so
+    what the write measures is attributable to no path. Equal depth is the
+    two-pass harvest/inject idiom and stays legal.
+    """
+    for ename, write in doc.writes.items():
+        target_site = str(write.site)
+        target = site_depth(doc, target_site)
+        for operand in _operand_names(write.do):
+            read = doc.reads.get(operand)
+            if read is None:
+                continue  # a param or a literal: no address, so no geometry
+            source_site = str(read.site)
+            if site_depth(doc, source_site) <= target:
+                continue
+            raise ValidationError(
+                20,
+                f"write {ename!r} takes its operand from read {operand!r} at "
+                f"{_site_label(doc, source_site)}, which is strictly deeper in "
+                f"the forward pass than the address it lands on, "
+                f"{_site_label(doc, target_site)}. The operand's model runs "
+                "first, so this is executable — but no edge of the network "
+                "carries information from the deeper address to the shallower "
+                "one, so the write is attributable to no path (§2.8). Read the "
+                "operand at or above the write's address; if it is meant as an "
+                "externally supplied constant rather than a routed activation, "
+                "harvest it in its own run and load it as a `params` entry "
+                "(§2.6).",
+                path=f"writes.{ename}.do",
             )

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -698,6 +698,19 @@ Closed mechanism set (`do` has exactly one key):
   order-free.
 - `gaussian.axis` tells a tensor-parallel engine whether the draw is
   replicated or sharded across ranks; `seed` is part of the hash.
+- **An operand is read from at or above the address it lands on** (rule 20).
+  Deeper is *executable* — the operand's model runs first, which is exactly
+  what sec. 2.9's acyclicity licenses — but the network has no edge from the
+  deeper address to the shallower one, so a write fed that way is attributable
+  to no path, and a number attributable to no path is what this rule exists to
+  refuse. Equal depth is the two-pass idiom: harvest a receiver's value in one
+  intervened model, inject it at that same address in another. If the value is
+  genuinely meant as an externally supplied constant rather than a routed
+  activation, say so — harvest it into a bundle in its own run and load it as a
+  `params` entry (sec. 2.6), where being a constant is the declared thing.
+  Because the order is `(layer, intra-block rank)` and not layer alone, the
+  rule is block-order aware: a head's contribution feeding the same layer's MLP
+  is upstream, and the reverse is refused.
 
 ### 2.9 `intervened_models`
 
@@ -1064,6 +1077,11 @@ A conforming loader rejects the document unless all of these hold:
     checklist, rule 19 is checked when the run encodes its inputs, **before any
     forward pass**, not at load. `validate` cannot decide it: the pure verbs
     hold no tokenizer, by design.
+20. Operand reachability: every write operand that names a **read** is read at
+    an address no deeper than the one the write lands on, in the `(layer,
+    intra-block rank)` order of sec. 2.4's vocabulary. Equal is legal — that is
+    the harvest/inject idiom. Params and literal-scalar operands have no
+    address and are unconstrained.
 
 ## 6. Derived — never authored
 

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -867,3 +867,205 @@ def test_decode_over_a_continuation_read_is_legal():
         }
     ]
     parse_and_validate(doc)
+
+
+# rule 20 — operand reachability -------------------------------------------- #
+
+
+def _two_site_doc(
+    read_site: dict[str, Any], write_site: dict[str, Any]
+) -> dict[str, Any]:
+    """A document whose write at ``write_site`` is fed from ``read_site``.
+
+    Deliberately additive: rule 20 is about where the operand came from, not
+    about the mechanism, and an `add_scaled` delta is the idiom that makes the
+    geometry load-bearing (a routed per-edge contribution, §2.8).
+    """
+    doc = base_doc()
+    doc["sites"]["src"] = read_site
+    doc["sites"]["dst"] = write_site
+    doc["reads"]["v_src"] = {
+        "site": "src",
+        "pos": -1,
+        "model": "original",
+        "input": "counterfactual",
+    }
+    # base_doc's own target read and site are replaced wholesale here, and an
+    # unreferenced read or site is rule 11 — which would mask rule 20.
+    doc["reads"].pop("v_cf")
+    doc["sites"].pop("tgt")
+    doc["writes"] = {
+        "patch": {
+            "site": "dst",
+            "pos": -1,
+            "do": {"add_scaled": {"op": "v_src", "alpha": 1.0}},
+        }
+    }
+    return doc
+
+
+def test_rule_20_operand_read_deeper_than_the_write_is_refused():
+    doc = _two_site_doc(
+        {"component": "block_output", "layer": 9},
+        {"component": "block_output", "layer": 3},
+    )
+    err = expect_rule(20, doc)
+    assert "'v_src'" in str(err) and "layer 9" in str(err) and "layer 3" in str(err)
+
+
+def test_rule_20_operand_read_upstream_of_the_write_is_legal():
+    parse_and_validate(
+        _two_site_doc(
+            {"component": "block_output", "layer": 1},
+            {"component": "block_output", "layer": 3},
+        )
+    )
+
+
+def test_rule_20_equal_depth_is_legal_because_that_is_harvest_inject():
+    """Corpus 03's shape: a receiver's value read in one model and injected at
+    the very same address in another. Equal depth must never be refused."""
+    parse_and_validate(
+        _two_site_doc(
+            {"component": "block_output", "layer": 3},
+            {"component": "block_output", "layer": 3},
+        )
+    )
+
+
+def test_rule_20_is_block_order_aware_within_one_layer():
+    """A head's residual contribution feeding the same layer's MLP is a real
+    sequential edge; the reverse direction is not."""
+    parse_and_validate(
+        _two_site_doc(
+            {"component": "attention_result", "layer": 3, "head": 1},
+            {"component": "mlp_input", "layer": 3},
+        )
+    )
+    err = expect_rule(
+        20,
+        _two_site_doc(
+            {"component": "mlp_output", "layer": 3},
+            {"component": "attention_output", "layer": 3},
+        ),
+    )
+    assert "mlp_output" in str(err) and "attention_output" in str(err)
+
+
+def test_rule_20_lm_head_sorts_after_every_block():
+    """The two layer-less trunk components are deeper than any block, so an
+    `lm_head`-derived operand can land nowhere but the trunk's own tail."""
+    doc = base_doc()
+    doc["reads"].pop("v_cf")
+    doc["reads"]["v_logits"] = {
+        "site": "lm_head",
+        "pos": -1,
+        "model": "original",
+        "input": "counterfactual",
+        "dims": list(range(768)),  # gpt2 hidden, so the widths agree
+    }
+    doc["writes"] = {
+        "patch": {
+            "site": "tgt",
+            "pos": -1,
+            "do": {"add_scaled": {"op": "v_logits", "alpha": 1.0}},
+        }
+    }
+    err = expect_rule(20, doc)
+    assert "lm_head" in str(err)
+
+
+def test_rule_20_ignores_params_and_literal_operands():
+    """A param has no address, so it has no geometry to be wrong about."""
+    doc = base_doc()
+    doc["params"] = {"bias": {"file_path": "p.safetensors"}}
+    doc["writes"] = {
+        "patch": {
+            "site": "tgt",
+            "pos": -1,
+            "do": {"add_scaled": {"op": "bias", "alpha": 1.0}},
+        }
+    }
+    doc["reads"].pop("v_cf")
+    parse_and_validate(doc)
+
+
+def test_rule_20_constrains_the_alpha_slot_too():
+    """`alpha` may name a read (§2.8 operands), and a coefficient taken from
+    downstream is as unattributable as a downstream value."""
+    doc = base_doc()
+    doc["sites"]["deep"] = {"component": "block_output", "layer": 9}
+    doc["reads"]["k"] = {
+        "site": "deep",
+        "pos": -1,
+        "model": "original",
+        "input": "counterfactual",
+        "dims": [0],
+    }
+    doc["writes"] = {
+        "patch": {
+            "site": "tgt",
+            "pos": -1,
+            "do": {"add_scaled": {"op": "v_cf", "alpha": "k"}},
+        }
+    }
+    err = expect_rule(20, doc)
+    assert "'k'" in str(err)
+
+
+def test_the_whole_corpus_is_upstream_or_equal():
+    """The rule is a *new refusal*, so its blast radius is the claim worth
+    pinning: no shipped document routes an operand backwards.
+
+    Read straight off the JSON rather than through the loader — that keeps the
+    claim about the authored corpus and not about one point of an expansion,
+    and it stays true for the two documents whose layer is a sweep or an
+    artifact reference (skipped here, concrete at every point, and covered by
+    ``test_corpus.py`` loading all of them under the live rule).
+    """
+    import json
+
+    from causalab.protocol.plan import COMPONENT_RANK, UNRANKED
+
+    from tests.protocol._env import CORPUS_DIR
+
+    def depth(site: dict[str, Any]) -> tuple[int, int] | None:
+        component = site["component"]
+        if component not in COMPONENT_RANK:
+            return None
+        rank = COMPONENT_RANK.get(component, UNRANKED)
+        if component in ("ln_final", "lm_head"):
+            return (1_000_000, rank)
+        layer = site.get("layer", 0)
+        return None if not isinstance(layer, int) else (layer, rank)
+
+    files = sorted(CORPUS_DIR.glob("*_im.json"))
+    assert files, "corpus did not resolve"
+    compared = 0
+    for path in files:
+        doc = json.loads(path.read_text())
+        sites, reads = doc.get("sites", {}), doc.get("reads", {})
+        for wname, write in doc.get("writes", {}).items():
+            payload = next(iter(write["do"].values()))
+            slots = (
+                [payload]
+                if isinstance(payload, str)
+                else [payload.get(k) for k in ("op", "alpha")]
+                if isinstance(payload, dict)
+                else []
+            )
+            target = depth(sites[write["site"]])
+            for slot in slots:
+                if not isinstance(slot, str) or slot not in reads:
+                    continue
+                source = depth(sites[reads[slot]["site"]])
+                if target is None or source is None:
+                    continue
+                compared += 1
+                assert source <= target, (
+                    f"{path.name}: write {wname!r} reads {slot!r} from deeper "
+                    f"({source} > {target}) — rule 20 would refuse it"
+                )
+    # 18, not 20: corpus 07's layer is a sweep and 08's is an artifact
+    # reference, so neither is comparable off the authored JSON.
+    assert compared >= 18, f"only {compared} operand edges compared"


### PR DESCRIPTION
## Why

Nothing checked that a write's operand came from an address the network can
route to it. A document could read a head's contribution at layer 20, add it
into the residual stream at layer 11, and get a number — one attributable to no
path, since no edge carries information backwards through the forward pass.

The reason it was never caught: the value is *computable*. §2.9 stages the
operand's model first, which is exactly what acyclicity licenses. So this is
**uninterpretable, not unexecutable**, and the loader only refused the latter.

This is the one insight worth keeping from the pre-protocol path-patching engine
in `causalab-internal#534`, whose `check_sender_reachability` refused nonphysical
sender→receiver edges. That engine's other three contributions this tree already
has independently — joint multi-edge routing (unbounded additive writes in one
intervened model), the q/k/v head-space receivers with GQA-narrowed head bounds,
and a derived `attn_eager` requirement — but nothing had replaced the
reachability check.

## What

Rule 20: every write operand naming a **read** is read at an address no deeper
than the one the write lands on, in the `(layer, intra-block rank)` order of
§2.4's vocabulary.

- **Equal is legal**, which is what keeps the two-pass harvest/inject idiom
  working (corpus 03: a receiver's value read in one intervened model, injected
  at that same address in another).
- **Block-order aware for free**, because the comparison reuses the order group
  elision already depends on: a head's contribution feeding the same layer's MLP
  is upstream, and the reverse is refused. `plan._depth` is promoted to
  `plan.site_depth` rather than duplicated — one home for the order, two readers.
- Params and literal-scalar operands have no address, so they are unconstrained.

## Blast radius

It is a new refusal, so this is the claim that matters: **all 14 corpus
documents are already upstream-or-equal** — 20 operand edges, 4 upstream and 16
equal, 0 downstream. Pinned by a test that reads the authored JSON directly, so
it stays a statement about the corpus rather than about one point of an
expansion.

Full suite: 2815 passed, 27 skipped.

## The escape, for a value that really is a constant

The refusal says it: if the operand is meant as an externally supplied constant
rather than a routed activation, harvest it into a bundle in its own run and load
it as a `params` entry (§2.6) — where being a constant is the declared thing,
instead of being smuggled in as an activation read from the wrong end of the
network.

## Verification

```
$ causalab validate nonphysical_im.json     # sender L20 -> receiver L11
refused: [V20] at writes.e7_on.do write 'e7_on' takes its operand from read
'r7_cf' at site 's7' (attention_result layer 20), which is strictly deeper in
the forward pass than the address it lands on, site 'recv' (block_mid layer 11).
...
$ causalab validate circuit_im.json         # the same document, senders below
OK: 1 point, digest 0f1875de7298420f…
```

Nine tests cover: downstream refused, upstream legal, equal legal, block-order
awareness within one layer (both directions), `lm_head` sorting after every
block, params/literal operands unconstrained, the `alpha` slot constrained too,
and the corpus-wide geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)