### PR TITLE
Corpus 15: circuit evaluation over a per-edge polarity map, closed against the write it reduces to

### DIFF
--- a/tests/neural/engines/pytorch_hooks/test_edge_delta_closure.py
+++ b/tests/neural/engines/pytorch_hooks/test_edge_delta_closure.py
@@ -14,10 +14,16 @@ trunk being linear all the way to the logits:
 
 so routing *every* head of layer L into the mixer output itself must land it
 on ``Σ_h result_cf + bias`` — which is ``attention_output`` on the
-counterfactual, exactly what swapping the whole mixer output produces. The
-bias belongs to no head and enters once, from the base value, so it cancels;
-the ``bundle`` fixture covers gpt2, whose o-projection *has* a bias, as well
-as llama, whose does not.
+counterfactual, exactly what swapping the whole mixer output produces.
+
+The o-projection bias belongs to no head, and it drops out for a reason worth
+stating precisely: it is the *same constant* in the base and counterfactual
+values, so it cancels in the difference **however the derivation attributes
+it** — the closure is insensitive to bias attribution rather than a test of it.
+What pins the attribution itself is
+``test_sites_round2_result.py::test_the_bias_belongs_to_no_head``. What the
+nonzero-bias test below adds is that a real bias, rather than the fixtures'
+absent (llama) or all-zero (gpt2) one, leaks no term into the closure.
 
 The receiver is ``attention_output`` and not ``block_mid``: a ``block_mid``
 write is currently only half-applied (it reaches the MLP but not the residual
@@ -30,15 +36,20 @@ which is the whole point: the nonlinearity is computed, not assumed.
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+import contextlib
+from typing import Any, Iterator, Sequence
 
 import pytest
 import torch
 
-from causalab.neural.engines.pytorch_hooks.loading import ModelBundle
+from causalab.neural.engines.pytorch_hooks.loading import ModelBundle, load_model
 
 from tests.neural.engines.pytorch_hooks._drive import base_data_section, executor_for
-from tests.neural.engines.pytorch_hooks.conftest import BASE_TEXT, COUNTERFACTUAL_TEXT
+from tests.neural.engines.pytorch_hooks.conftest import (
+    BASE_TEXT,
+    COUNTERFACTUAL_TEXT,
+    TINY_GPT2,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -177,10 +188,7 @@ def _clean_doc() -> dict[str, Any]:
 
 
 def test_routing_every_head_equals_swapping_the_mixer_output(bundle: ModelBundle):
-    """Patch-everything closure. ``Σ_h attention_result == attention_output``
-    minus the o-projection bias, and the bias enters once from the base value,
-    so the all-heads edge set must be indistinguishable from the swap — on
-    gpt2 (biased o-projection) as well as llama (unbiased)."""
+    """Patch-everything closure, on both families in the fixture."""
     every_head = range(bundle.info.num_heads)
     torch.testing.assert_close(
         _logits(_edge_delta_doc(every_head), bundle),
@@ -288,3 +296,44 @@ def test_a_block_mid_write_does_not_reach_the_residual_skip(
     # the write did land where it was addressed — this is not a lost write
     torch.testing.assert_close(mid, executor.read_value("v_cf"), **TOL)
     torch.testing.assert_close(out - mlp, mid, **TOL)
+
+
+@contextlib.contextmanager
+def _nonzero_o_projection_bias(bundle: ModelBundle, layer: int) -> Iterator[None]:
+    """Give gpt2's attention output projection a bias that is actually there.
+
+    The fixture ships zeros, which cannot tell "the bias cancels" apart from
+    "the bias is dropped". Restored on the way out — the bundle is
+    session-cached, so leaving it perturbed would leak into every later test.
+    """
+    proj = bundle.model.transformer.h[layer].attn.c_proj
+    assert proj.bias is not None, "gpt2's c_proj is expected to carry a bias"
+    saved = proj.bias.detach().clone()
+    with torch.no_grad():
+        proj.bias.copy_(torch.linspace(-0.7, 0.7, proj.bias.numel()))
+    try:
+        yield
+    finally:
+        with torch.no_grad():
+            proj.bias.copy_(saved)
+
+
+def test_the_closure_holds_with_a_nonzero_o_projection_bias():
+    """The one term the per-head derivation cannot attribute, made real.
+
+    Both fixtures dodge it — llama's o-projection has no bias, tiny-random
+    gpt2's is all zeros — so the closure above never meets one. It should not
+    care: the bias is the same constant on both inputs and cancels in the
+    difference. This asserts that it does not care, which is a weaker and more
+    honest claim than "this pins the bias".
+    """
+    bundle = load_model(TINY_GPT2)
+    with _nonzero_o_projection_bias(bundle, LAYER):
+        assert bundle.model.transformer.h[LAYER].attn.c_proj.bias.abs().max() > 0
+        torch.testing.assert_close(
+            _logits(_edge_delta_doc(range(bundle.info.num_heads)), bundle),
+            _logits(_mixer_swap_doc(), bundle),
+            **TOL,
+        )
+    # and the perturbation really was undone
+    assert bundle.model.transformer.h[LAYER].attn.c_proj.bias.abs().max() == 0

--- a/tests/neural/engines/pytorch_hooks/test_edge_delta_closure.py
+++ b/tests/neural/engines/pytorch_hooks/test_edge_delta_closure.py
@@ -1,0 +1,290 @@
+"""Per-edge delta routing, closed against the write it must reduce to.
+
+Corpus 15's idiom: an *edge* — one attention head's contribution to one
+residual receiver — is routed to its counterfactual value by a pair of
+additive writes at the receiver, ``+1`` on the counterfactual read of
+``attention_result`` and ``-1`` on the base read. Any number of such pairs
+compose in one intervened model (§2.8: unbounded additive writes at one
+address), which is what lets a whole edge set run as one joint forward.
+
+The identity that makes it exact is structural, not an assumption about the
+trunk being linear all the way to the logits:
+
+    attention_output(L) = Σ_h attention_result(L, h) + o_proj_bias
+
+so routing *every* head of layer L into the mixer output itself must land it
+on ``Σ_h result_cf + bias`` — which is ``attention_output`` on the
+counterfactual, exactly what swapping the whole mixer output produces. The
+bias belongs to no head and enters once, from the base value, so it cancels;
+the ``bundle`` fixture covers gpt2, whose o-projection *has* a bias, as well
+as llama, whose does not.
+
+The receiver is ``attention_output`` and not ``block_mid``: a ``block_mid``
+write is currently only half-applied (it reaches the MLP but not the residual
+skip) — goodfire-ai/causalab#79, pinned by
+``test_a_block_mid_write_does_not_reach_the_residual_skip`` below.
+
+Everything downstream of the receiver is a real forward in both documents,
+which is the whole point: the nonlinearity is computed, not assumed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import pytest
+import torch
+
+from causalab.neural.engines.pytorch_hooks.loading import ModelBundle
+
+from tests.neural.engines.pytorch_hooks._drive import base_data_section, executor_for
+from tests.neural.engines.pytorch_hooks.conftest import BASE_TEXT, COUNTERFACTUAL_TEXT
+
+pytestmark = pytest.mark.unit
+
+#: Wrapper-level tolerance, as for the other cross-document write cases: the
+#: two forwards differ only in accumulation order at the receiver.
+TOL = dict(atol=1e-5, rtol=1e-4)
+
+LAYER = 1
+
+
+def _logits(doc: dict[str, Any], bundle: ModelBundle) -> torch.Tensor:
+    executor = executor_for(
+        doc,
+        bundle,
+        base_texts=[BASE_TEXT],
+        counterfactual_texts=[COUNTERFACTUAL_TEXT],
+    )
+    return executor.read_value("logits")
+
+
+def _logits_read(model: str) -> dict[str, Any]:
+    return {
+        "site": "lm_head",
+        "pos": {"index": -1},
+        "model": model,
+        "input": "base",
+    }
+
+
+def _save_logits(model: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "value": "logits",
+            "model": model,
+            "input": "base",
+            "file_path": "logits.safetensors",
+        }
+    ]
+
+
+def _edge_delta_doc(
+    heads: Sequence[int], *, layer: int = LAYER, self_cancel: bool = False
+) -> dict[str, Any]:
+    """Route each head in ``heads`` at ``layer`` into that layer's own
+    residual receiver, by an additive ``+counterfactual`` / ``-base`` pair.
+
+    ``self_cancel`` routes each head to its *own base* value instead — a pair
+    that sums to zero, which is the patch-nothing end of the closure.
+    """
+    sites: dict[str, Any] = {
+        "recv": {"component": "attention_output", "layer": layer},
+        "lm_head": {"component": "lm_head"},
+    }
+    reads: dict[str, Any] = {}
+    writes: dict[str, Any] = {}
+    for head in heads:
+        sites[f"h{head}"] = {
+            "component": "attention_result",
+            "layer": layer,
+            "head": head,
+        }
+        for role, tag in (("base", "b"), ("counterfactual", "c")):
+            reads[f"{tag}{head}"] = {
+                "site": f"h{head}",
+                "pos": {"index": -1},
+                "model": "original",
+                "input": role,
+            }
+        on_operand = f"b{head}" if self_cancel else f"c{head}"
+        writes[f"on{head}"] = {
+            "site": "recv",
+            "pos": {"index": -1},
+            "do": {"add_scaled": {"op": on_operand, "alpha": 1.0}},
+        }
+        writes[f"off{head}"] = {
+            "site": "recv",
+            "pos": {"index": -1},
+            "do": {"add_scaled": {"op": f"b{head}", "alpha": -1.0}},
+        }
+    if self_cancel:
+        # the counterfactual reads would be dead declarations (rule 11)
+        for head in heads:
+            reads.pop(f"c{head}")
+    reads["logits"] = _logits_read("routed")
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=not self_cancel),
+        "sites": sites,
+        "reads": reads,
+        "writes": writes,
+        "intervened_models": {
+            "routed": {"input": "base", "writes": sorted(writes)},
+        },
+        "save": _save_logits("routed"),
+    }
+
+
+def _mixer_swap_doc(*, layer: int = LAYER) -> dict[str, Any]:
+    """The write the all-heads edge set must reduce to: the whole mixer output
+    at ``layer`` swapped to its counterfactual value."""
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=True),
+        "sites": {
+            "mix": {"component": "attention_output", "layer": layer},
+            "lm_head": {"component": "lm_head"},
+        },
+        "reads": {
+            "v_cf": {
+                "site": "mix",
+                "pos": {"index": -1},
+                "model": "original",
+                "input": "counterfactual",
+            },
+            "logits": _logits_read("routed"),
+        },
+        "writes": {
+            "swap": {"site": "mix", "pos": {"index": -1}, "do": {"swap": "v_cf"}}
+        },
+        "intervened_models": {"routed": {"input": "base", "writes": ["swap"]}},
+        "save": _save_logits("routed"),
+    }
+
+
+def _clean_doc() -> dict[str, Any]:
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=False),
+        "sites": {"lm_head": {"component": "lm_head"}},
+        "reads": {"logits": _logits_read("original")},
+        "save": _save_logits("original"),
+    }
+
+
+def test_routing_every_head_equals_swapping_the_mixer_output(bundle: ModelBundle):
+    """Patch-everything closure. ``Σ_h attention_result == attention_output``
+    minus the o-projection bias, and the bias enters once from the base value,
+    so the all-heads edge set must be indistinguishable from the swap — on
+    gpt2 (biased o-projection) as well as llama (unbiased)."""
+    every_head = range(bundle.info.num_heads)
+    torch.testing.assert_close(
+        _logits(_edge_delta_doc(every_head), bundle),
+        _logits(_mixer_swap_doc(), bundle),
+        **TOL,
+    )
+
+
+def test_routing_no_head_reproduces_the_clean_run(bundle: ModelBundle):
+    """Patch-nothing closure, through the machinery rather than around it:
+    ``+1·base -1·base`` is a live pair of additive writes that sums to zero."""
+    torch.testing.assert_close(
+        _logits(
+            _edge_delta_doc(range(bundle.info.num_heads), self_cancel=True), bundle
+        ),
+        _logits(_clean_doc(), bundle),
+        **TOL,
+    )
+
+
+def test_one_edge_is_not_the_whole_mixer(bundle: ModelBundle):
+    """The guard that keeps the closure honest: if a single head's delta
+    already equalled the full swap, the two closures above would be passing
+    for a reason that has nothing to do with per-edge routing."""
+    if bundle.info.num_heads < 2:
+        pytest.skip("a one-head model cannot distinguish an edge from the mixer")
+    one = _logits(_edge_delta_doc([0]), bundle)
+    whole = _logits(_mixer_swap_doc(), bundle)
+    assert not torch.allclose(one, whole, **TOL), (
+        "one head's contribution reproduced the whole mixer swap — the "
+        "per-head derivation is not attributing anything"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# why the receiver above is not `block_mid`
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "a block_mid write is half-applied: it reaches post_attention_layernorm "
+        "(so the MLP sees it) but not the residual skip, which HF's decoder "
+        "layer captured from the same tensor before the norm ran. §2.4 states "
+        "block_output = block_mid + mlp_output, and under a write that identity "
+        "silently fails. goodfire-ai/causalab#79 — remove this marker with "
+        "the fix."
+    ),
+)
+def test_a_block_mid_write_does_not_reach_the_residual_skip(
+    llama_bundle: ModelBundle,
+):
+    """§2.4's second block identity, under a write at ``block_mid``.
+
+    Read in the *same* intervened model, ``block_output - mlp_output`` must be
+    the ``block_mid`` that model actually has. It is instead the pre-write
+    value, so the write moved the MLP's input and left the skip alone.
+
+    Note the sibling identity ``block_output == block_input +
+    attention_output + mlp_output`` is *blind* to this: a block_mid write
+    touches neither of the first two terms, so it holds either way. Only the
+    two-term form catches it.
+    """
+    pos = {"index": -1}
+    doc = {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=True),
+        "sites": {
+            "mid": {"component": "block_mid", "layer": LAYER},
+            "mlp": {"component": "mlp_output", "layer": LAYER},
+            "out": {"component": "block_output", "layer": LAYER},
+        },
+        "reads": {
+            "v_cf": {
+                "site": "mid",
+                "pos": pos,
+                "model": "original",
+                "input": "counterfactual",
+            },
+            "r_mid": {"site": "mid", "pos": pos, "model": "m", "input": "base"},
+            "r_mlp": {"site": "mlp", "pos": pos, "model": "m", "input": "base"},
+            "r_out": {"site": "out", "pos": pos, "model": "m", "input": "base"},
+        },
+        "writes": {"swap": {"site": "mid", "pos": pos, "do": {"swap": "v_cf"}}},
+        "intervened_models": {"m": {"input": "base", "writes": ["swap"]}},
+        "save": [
+            {
+                "value": name,
+                "model": "m",
+                "input": "base",
+                "file_path": f"{name}.safetensors",
+            }
+            for name in ("r_mid", "r_mlp", "r_out")
+        ],
+    }
+    executor = executor_for(
+        doc,
+        llama_bundle,
+        base_texts=[BASE_TEXT],
+        counterfactual_texts=[COUNTERFACTUAL_TEXT],
+    )
+    mid, mlp, out = (executor.read_value(n) for n in ("r_mid", "r_mlp", "r_out"))
+    # the write did land where it was addressed — this is not a lost write
+    torch.testing.assert_close(mid, executor.read_value("v_cf"), **TOL)
+    torch.testing.assert_close(out - mlp, mid, **TOL)

--- a/tests/neural/engines/pytorch_hooks/test_run_corpus.py
+++ b/tests/neural/engines/pytorch_hooks/test_run_corpus.py
@@ -107,6 +107,38 @@ def test_03_path_patching_runs(roots, tmp_path):
     assert len(ld) == 3
 
 
+def test_15_circuit_edges_runs(roots, tmp_path):
+    """The per-edge polarity map, executed: eight additive writes at one
+    address, two intervened models, and the two edge sets must not land on the
+    same number as the clean run or as each other — the whole point is that
+    which edges are routed changes the metric."""
+    code = _run(
+        "15_circuit_edges_im.json",
+        roots,
+        tmp_path,
+        # the fixture has two layers, so every sender is layer 0 and the
+        # receiver is the residual entering layer 1 — still strictly upstream
+        "sites.nm_9_6.layer=0",
+        "sites.nm_9_6.head=1",
+        "sites.nm_9_9.layer=0",
+        "sites.nm_9_9.head=2",
+        "sites.nm_10_0.layer=0",
+        "sites.nm_10_0.head=0",
+        "sites.ctl_10_7.layer=0",
+        "sites.ctl_10_7.head=3",
+        "sites.recv.layer=1",
+    )
+    assert code == 0
+    clean = table_frame(tmp_path / "ld_clean.json")["value"]
+    circuit = table_frame(tmp_path / "ld_circuit.json")["value"]
+    complement = table_frame(tmp_path / "ld_complement.json")["value"]
+    assert len(clean) == len(circuit) == len(complement) == 3
+    # routing edges moved the metric, and the two edge sets are distinguishable
+    assert not clean.equals(circuit)
+    assert not clean.equals(complement)
+    assert not circuit.equals(complement)
+
+
 def test_06_hydra_effect_runs(roots, tmp_path):
     code = _run(
         "06_hydra_effect_im.json",

--- a/tests/protocol/corpus_digests.json
+++ b/tests/protocol/corpus_digests.json
@@ -155,5 +155,11 @@
     "points": [
       "932f21f09dbb5d2343206705e36d700fa1a515ec872818aa2f9b9a0a862aaee9"
     ]
+  },
+  "15_circuit_edges_im.json": {
+    "document": "d391f57f1733127ee526bc14f8ac3aa8662b6d827e7a9d0534d98d23d6e81bef",
+    "points": [
+      "d391f57f1733127ee526bc14f8ac3aa8662b6d827e7a9d0534d98d23d6e81bef"
+    ]
   }
 }

--- a/tests/protocol/test_corpus.py
+++ b/tests/protocol/test_corpus.py
@@ -128,6 +128,14 @@ CORPUS_SHAPE = [
         2,
         {"paired_forward"} | _touch("block_output+w", "lm_head"),
     ),
+    (
+        # Eight writes, two intervened models, four forwards: the per-edge
+        # polarity map costs one joint forward per edge set, not one per edge.
+        "15_circuit_edges_im.json",
+        1,
+        4,
+        {"paired_forward"} | _touch("attention_result", "block_input+w", "lm_head"),
+    ),
 ]
 
 

--- a/tests/protocols/15_circuit_edges_im.json
+++ b/tests/protocols/15_circuit_edges_im.json
@@ -1,0 +1,260 @@
+{
+  "version": "1",
+  "description": "Circuit evaluation over an explicit per-edge polarity map (IOI name movers): each edge is one attention head's contribution to the residual stream entering a later layer, routed to its counterfactual value by a pair of additive writes (+1 on the counterfactual read of `attention_result`, -1 on the base read) and routed to base by being absent. The whole edge set is in force in one forward, so the paths interact through the real model rather than through an assumption that the trunk is additive downstream of the receiver; the complement set is the off-circuit control. Stacking one-edge runs cannot produce this, which is why an edge set is one document and not a composition of documents.",
+  "model": {
+    "key": "meta-llama/Llama-3.1-8B",
+    "revision": "main"
+  },
+  "data": {
+    "base": {
+      "dataset": "ioi/test",
+      "field": "input"
+    },
+    "counterfactual": {
+      "dataset": "ioi/test",
+      "field": "counterfactual_inputs[0]"
+    }
+  },
+  "sites": {
+    "nm_9_6": {
+      "component": "attention_result",
+      "layer": 9,
+      "head": 6
+    },
+    "nm_9_9": {
+      "component": "attention_result",
+      "layer": 9,
+      "head": 9
+    },
+    "nm_10_0": {
+      "component": "attention_result",
+      "layer": 10,
+      "head": 0
+    },
+    "ctl_10_7": {
+      "component": "attention_result",
+      "layer": 10,
+      "head": 7
+    },
+    "recv": {
+      "component": "block_input",
+      "layer": 11
+    },
+    "lm_head": {
+      "component": "lm_head"
+    }
+  },
+  "reads": {
+    "b_9_6": {
+      "site": "nm_9_6",
+      "pos": -1,
+      "model": "original",
+      "input": "base"
+    },
+    "c_9_6": {
+      "site": "nm_9_6",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "b_9_9": {
+      "site": "nm_9_9",
+      "pos": -1,
+      "model": "original",
+      "input": "base"
+    },
+    "c_9_9": {
+      "site": "nm_9_9",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "b_10_0": {
+      "site": "nm_10_0",
+      "pos": -1,
+      "model": "original",
+      "input": "base"
+    },
+    "c_10_0": {
+      "site": "nm_10_0",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "b_10_7": {
+      "site": "ctl_10_7",
+      "pos": -1,
+      "model": "original",
+      "input": "base"
+    },
+    "c_10_7": {
+      "site": "ctl_10_7",
+      "pos": -1,
+      "model": "original",
+      "input": "counterfactual"
+    },
+    "logits_clean": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "original",
+      "input": "base"
+    },
+    "logits_circuit": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "circuit",
+      "input": "base"
+    },
+    "logits_complement": {
+      "site": "lm_head",
+      "pos": -1,
+      "model": "complement",
+      "input": "base"
+    }
+  },
+  "writes": {
+    "on_9_6": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "c_9_6",
+          "alpha": 1.0
+        }
+      }
+    },
+    "off_9_6": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "b_9_6",
+          "alpha": -1.0
+        }
+      }
+    },
+    "on_9_9": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "c_9_9",
+          "alpha": 1.0
+        }
+      }
+    },
+    "off_9_9": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "b_9_9",
+          "alpha": -1.0
+        }
+      }
+    },
+    "on_10_0": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "c_10_0",
+          "alpha": 1.0
+        }
+      }
+    },
+    "off_10_0": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "b_10_0",
+          "alpha": -1.0
+        }
+      }
+    },
+    "on_10_7": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "c_10_7",
+          "alpha": 1.0
+        }
+      }
+    },
+    "off_10_7": {
+      "site": "recv",
+      "pos": -1,
+      "do": {
+        "add_scaled": {
+          "op": "b_10_7",
+          "alpha": -1.0
+        }
+      }
+    }
+  },
+  "intervened_models": {
+    "circuit": {
+      "input": "base",
+      "writes": [
+        "on_9_6",
+        "off_9_6",
+        "on_9_9",
+        "off_9_9",
+        "on_10_0",
+        "off_10_0"
+      ]
+    },
+    "complement": {
+      "input": "base",
+      "writes": [
+        "on_10_7",
+        "off_10_7"
+      ]
+    }
+  },
+  "metrics": {
+    "ld_clean": {
+      "kind": "logit_diff",
+      "of": "logits_clean",
+      "a": "answer",
+      "b": "cf_answer",
+      "token_form": "space_prefixed"
+    },
+    "ld_circuit": {
+      "kind": "logit_diff",
+      "of": "logits_circuit",
+      "a": "answer",
+      "b": "cf_answer",
+      "token_form": "space_prefixed"
+    },
+    "ld_complement": {
+      "kind": "logit_diff",
+      "of": "logits_complement",
+      "a": "answer",
+      "b": "cf_answer",
+      "token_form": "space_prefixed"
+    }
+  },
+  "save": [
+    {
+      "value": "ld_clean",
+      "model": "original",
+      "input": "base",
+      "file_path": "ld_clean.json"
+    },
+    {
+      "value": "ld_circuit",
+      "model": "circuit",
+      "input": "base",
+      "file_path": "ld_circuit.json"
+    },
+    {
+      "value": "ld_complement",
+      "model": "complement",
+      "input": "base",
+      "file_path": "ld_complement.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

`causalab-internal#534` argued against the *old* tree that its path-patching
method could not express a paper's circuit evaluation: it was
single-sender/all-others-frozen, and N single-edge passes are not the subgraph
pass, because the metric is nonlinear and the paths interact. That diagnosis was
right about the old API, and it is dissolved by this one — §2.8 allows unbounded
additive writes at one address, so an arbitrary per-edge polarity map is one
intervened model and one joint forward.

Nothing in the corpus said so. Corpus 15 does.

## The idiom

An **edge** is one head's contribution to a residual receiver:

| routing | how it is written |
|---|---|
| to counterfactual | `+1` on the counterfactual read of `attention_result`, `-1` on the base read |
| to base | absent |

Three name-mover edges are the circuit, one off-circuit head is the control, and
`explain` derives **four forwards** for the whole thing — two cache passes plus
one joint forward per edge set, not one per edge. No existing digest moved. The
document is also *run* end to end against the two-layer fixture, asserting that
routing moves the metric and that the two edge sets are distinguishable from
each other and from the clean run — a run that quietly wrote nothing would
produce three identical columns.

## The closure test is what makes it a claim

`attention_output == Σ_h attention_result + o_proj_bias`, so routing *every* head
must be indistinguishable from swapping the whole mixer output. It is, on both
families.

- **patch-everything** closes against the mixer swap.
- **patch-nothing** closes against the clean run, through a live `+1/-1` pair
  that sums to zero rather than around the machinery.
- **one edge ≠ the whole mixer** keeps the other two honest. Without it the
  closures could pass for a reason unrelated to per-edge routing.
- **a nonzero o-projection bias** leaks no term into the closure. Both fixtures
  dodge the bias otherwise — llama's projection has none and tiny-random gpt2's
  is all zeros — so this one sets a real one and restores it.

On the bias, stated precisely (an earlier commit message here overclaimed it,
and the third commit corrects it): the bias is the same constant on both inputs,
so it cancels in the difference **however the per-head derivation attributes
it**. The closure is therefore *insensitive* to attribution, not a test of it —
attribution is pinned by
`test_sites_round2_result.py::test_the_bias_belongs_to_no_head`, which already
did that job.

Unlike the analytic cache-arithmetic engine that PR proposed, nothing here
assumes the trunk is additive downstream of the receiver — everything past it is
a real forward. So there are no construction guards to maintain, and MoE /
DeltaNet layers are not special cases.

## A bug fell out

Writing the closure found one: **a `block_mid` write is half-applied.** It lands
at its own tap (a later read returns the written value) but not at the residual
skip, so §2.4's `block_output = block_mid + mlp_output` silently fails under it.
Measured on tiny-random llama, layer 1: `block_output - mlp_output` matches the
*unwritten* `block_mid` to 9.3e-10 and misses the written one by 8.5e-2.

The sibling identity `block_output == block_input + attention_output +
mlp_output` is **blind** to this — a `block_mid` write touches neither of the
first two terms — which is presumably why it survived.

The receiver here is `block_input` (corpus 03's own receiver shape) because of
it. The defect is pinned by a strict xfail and filed as #79, along with a second,
smaller one: `block_mid` on GPT-2 raises `AttributeError` rather than refusing
cleanly, since the module is `ln_2` there.

Full suite: 2819 passed, 27 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)